### PR TITLE
fix(types): align employees schema with actual database (profile_id, …

### DIFF
--- a/lib/interfaces/database.types.ts
+++ b/lib/interfaces/database.types.ts
@@ -126,13 +126,14 @@ export type Database = {
           federal_tax_rate: number | null
           first_name: string | null
           hire_date: string
+          hours_per_week: number | null
           id: string
           last_name: string | null
           pay_frequency: string
           pay_rate: number
           phone: string | null
           position: string
-          "profile.id": string | null
+          profile_id: string | null
           role: string | null
           social_security_tax_rate: number | null
           state: string | null
@@ -152,13 +153,14 @@ export type Database = {
           federal_tax_rate?: number | null
           first_name?: string | null
           hire_date: string
+          hours_per_week?: number | null
           id?: string
           last_name?: string | null
           pay_frequency: string
           pay_rate: number
           phone?: string | null
           position: string
-          "profile.id"?: string | null
+          profile_id?: string | null
           role?: string | null
           social_security_tax_rate?: number | null
           state?: string | null
@@ -178,13 +180,14 @@ export type Database = {
           federal_tax_rate?: number | null
           first_name?: string | null
           hire_date?: string
+          hours_per_week?: number | null
           id?: string
           last_name?: string | null
           pay_frequency?: string
           pay_rate?: number
           phone?: string | null
           position?: string
-          "profile.id"?: string | null
+          profile_id?: string | null
           role?: string | null
           social_security_tax_rate?: number | null
           state?: string | null
@@ -202,7 +205,7 @@ export type Database = {
           },
           {
             foreignKeyName: "employees_profile.id_fkey"
-            columns: ["profile.id"]
+            columns: ["profile_id"]
             isOneToOne: false
             referencedRelation: "profiles"
             referencedColumns: ["id"]


### PR DESCRIPTION
…hours_per_week)

The Supabase-generated types had drifted from the real schema and were failing Vercel's TypeScript build:

- Renamed the `employees` column from `"profile.id"` (a stale dotted identifier) to `profile_id` across Row/Insert/Update and the Relationships `columns` array. The real Postgres column is `profile_id` — confirmed at runtime by the 42703 error hint "Perhaps you meant to reference the column employees.profile_id". This unblocks `app/internal-search/actions.ts` and `lib/supabase/employee.tsx`, which call `.eq('profile_id', ...)`.
- Added the missing `hours_per_week` column declaration so the types match what the DB actually exposes.
- Left the `employees_profile.id_fkey` foreignKeyName literal alone: Postgres does not auto-rename FK constraints when a column is renamed, and nothing in the codebase embeds via that name (grep confirmed it's referenced only inside this file).

Follow-up: regenerate this file from the live schema with `npx supabase gen types typescript --project-id <ref>` so we stop hand-maintaining drift; that pass will pick up the real FK name too.