### PR TITLE
ci: narrow validate-renovate trigger and drop dead CodeQL build step

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,17 +61,6 @@ jobs:
         build-mode: ${{ matrix.build-mode }}
         queries: security-extended,security-and-quality
  
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
       with:

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -5,10 +5,6 @@ on:
     pull_request:
         paths:
             - ".github/renovate.json"
-            - ".github/renovate/**"
-            - "renovate.json"
-            - "renovate.json5"
-            - ".renovaterc*"
     workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Applies the shared CI workflow fixes from the [workflow-fixes rollout](https://github.com/SamuelIVX/SamuelIVX.github.io).

- **validate-renovate.yml**: narrow the PR trigger to only the file actually validated (`.github/renovate.json`) — no more CI passing while validating the wrong/nonexistent config.
- **codeql.yml** (`ecommerceWebsite`, `MetricForge`, `introToWebDev`): drop the placeholder "Run manual build steps" step that always `exit 1`s. All matrix languages use `build-mode: none`, so this is dead code.
- **linter.yml** (`introToWebDev` only): fix stray spaces in the branch list and run Super-Linter in PR mode (`VALIDATE_ALL_CODEBASE: push` only) instead of the whole codebase on every PR.

Verified against the pilot repo (SamuelIVX.github.io) which already runs these checks green.