### PR TITLE
docs: add file headers, export docstrings, and link TODOs to issues

### DIFF
--- a/app/employee/benefits/page.tsx
+++ b/app/employee/benefits/page.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+/**
+ * Employee benefits page: company + optional enrollment with eligibility gating.
+ */
 import { useState, useEffect, useMemo } from "react"
 import { Info } from "lucide-react"
 import SummaryCards from "@/components/employee/summary-cards/SummaryCards"
@@ -18,6 +21,9 @@ import { getApprovedHoursWorked } from "@/lib/supabase/time-entries"
 import { checkOptionalBenefitsEligibility } from "@/lib/benefits/eligibility"
 import type { EmployeeBenefit, BenefitOption } from "@/app/employee/benefits/types"
 
+/**
+ * Default export: Benefits Page.
+ */
 export default function BenefitsPage() {
   const [employeeId, setEmployeeId] = useState<string>("");
   const [employmentStatus, setEmploymentStatus] = useState<string | null>(null);

--- a/app/employee/benefits/types.ts
+++ b/app/employee/benefits/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Prop/types for the employee benefits page.
+ */
 export interface BenefitOption {
     id: string;
     benefit: string;
@@ -6,6 +9,9 @@ export interface BenefitOption {
     [key: string]: unknown;
 }
 
+/**
+ * EmployeeBenefit type/interface.
+ */
 export interface EmployeeBenefit {
     benefit_id: string;
     status: 'ACTIVE' | 'NOT_ENROLLED';

--- a/app/employee/dashboard/page.tsx
+++ b/app/employee/dashboard/page.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+/**
+ * Employee dashboard: hours, stats, timesheets, and grid cards.
+ */
 import * as React from "react"
 
 import { type ChartConfig } from "@/components/ui/chart"
@@ -30,6 +33,9 @@ const initialTimesheets = [
 
 const weeklyTarget = 40
 
+/**
+ * Default export: Employee Dashboard Page.
+ */
 export default function EmployeeDashboardPage() {
 
   const [hoursByDay, setHoursByDay] = React.useState<HoursByDay[]>(initialHoursByDay)

--- a/app/employee/paystubs/__tests__/PayStubs.test.tsx
+++ b/app/employee/paystubs/__tests__/PayStubs.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for app/employee/paystubs.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { COMPANY_INFO } from '@/app/employee/paystubs/utils';

--- a/app/employee/paystubs/__tests__/utils.test.ts
+++ b/app/employee/paystubs/__tests__/utils.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for app/employee/paystubs.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { processPaystubData } from '@/app/employee/paystubs/utils';
 import type { RawPaystubRow } from '@/app/employee/paystubs/types';

--- a/app/employee/paystubs/page.tsx
+++ b/app/employee/paystubs/page.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+/**
+ * Employee paystubs list + PDF download UI.
+ * SECURITY: displays net pay and address from payroll records.
+ */
 import { useEffect, useState } from "react";
 import { Download, ChevronDown } from "lucide-react";
 import { PDFDownloadLink } from "@react-pdf/renderer";
@@ -283,6 +287,9 @@ function PayStubCard({
   );
 }
 
+/**
+ * Default export: Pay Stubs Page.
+ */
 export default function PayStubsPage() {
   const [paystubs, setPaystubs] = useState<ProcessedPaystub[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/employee/paystubs/types.ts
+++ b/app/employee/paystubs/types.ts
@@ -1,9 +1,15 @@
+/**
+ * Raw and processed paystub row types for the employee paystubs UI.
+ */
 export interface PaystubInfoProps {
 	title: string;
 	value: string | number;
 	valueClassName?: string;
 }
 
+/**
+ * PayStub type/interface.
+ */
 export interface PayStub {
 	id: string;
 	period: string;
@@ -14,6 +20,9 @@ export interface PayStub {
 	benefits: number;
 }
 
+/**
+ * CheckData type/interface.
+ */
 export interface CheckData {
 	employeeName: string;
 	employeeAddress: string;
@@ -43,6 +52,9 @@ export interface CheckData {
 	companyAddress: string;
 	companyPhone: string;
 }
+/**
+ * RawPaystubRow type/interface.
+ */
 export interface RawPaystubRow {
 	id: string;
 	regular_hours: number | null;
@@ -83,6 +95,9 @@ export interface RawPaystubRow {
 	ytd_net_pay?: number;
 }
 
+/**
+ * PayStubRowProps type/interface.
+ */
 export interface PayStubRowProps {
 	label: string;
 	current: number;
@@ -90,6 +105,9 @@ export interface PayStubRowProps {
 	isNegative?: boolean;
 	isBold?: boolean;
 }
+/**
+ * ProcessedPaystub type/interface.
+ */
 export interface ProcessedPaystub extends CheckData {
 	id: string;
 	period: string;

--- a/app/employee/paystubs/utils.ts
+++ b/app/employee/paystubs/utils.ts
@@ -1,6 +1,11 @@
+/**
+ * Maps raw payroll_record rows into ProcessedPaystub for PDF/UI; company letterhead constants.
+ * SECURITY: processes compensation and address PII.
+ */
 import { formatPayPeriod, formatPaidOn } from "@/lib/utils";
 import type { RawPaystubRow, CheckData, ProcessedPaystub } from "./types";
 
+/** Letterhead constants stamped onto generated paystub PDFs. */
 export const COMPANY_INFO = {
   name: "PayCore Inc.",
   address: "123 Business Ave",
@@ -8,6 +13,11 @@ export const COMPANY_INFO = {
   phone: "(555) 123-4567",
 };
 
+/**
+ * Deterministic pseudo-random in [min, min+range) from a string seed.
+ * Used for synthetic YTD/SSN display values on demo paystubs (not real SSN).
+ * SECURITY: output can look like an SSN — never treat as a real identifier.
+ */
 function stableNumber(seed: string, min: number, range: number): number {
   let hash = 0;
   for (let i = 0; i < seed.length; i++) {
@@ -16,6 +26,10 @@ function stableNumber(seed: string, min: number, range: number): number {
   return min + (Math.abs(hash) % range);
 }
 
+/**
+ * Normalizes a RawPaystubRow into ProcessedPaystub for PDF/list UI.
+ * SECURITY: carries pay and address fields through to the PDF.
+ */
 export function processPaystubData(row: RawPaystubRow): ProcessedPaystub {
   const payrollRun = row.payroll_runs;
   const employee = row.employees;

--- a/app/internal-search/actions.ts
+++ b/app/internal-search/actions.ts
@@ -1,5 +1,9 @@
 'use server';
 
+/**
+ * Server actions for directory search and authenticated role lookup.
+ * SECURITY: role gates which employee fields are returned (pay/address vs visitor-safe).
+ */
 import { createClient } from "@/utils/supabase/server";
 import type { EmployeeWithProfile } from "@/lib/supabase/employee";
 
@@ -33,6 +37,10 @@ async function resolveAuthenticatedRole(
     return employee?.role ?? 'visitor';
 }
 
+/**
+ * Server-side name search returning role-appropriate employee fields.
+ * SECURITY: pay/address only for elevated roles.
+ */
 export async function searchEmployeesByNameAction(
     name: string,
 ): Promise<{ results: EmployeeWithProfile[]; role: string }> {
@@ -69,6 +77,9 @@ export async function searchEmployeesByNameAction(
     };
 }
 
+/**
+ * Returns the signed-in profiles.role string (or empty when unauthenticated).
+ */
 export async function getAuthenticatedUserRoleAction(): Promise<string> {
     const supabase = await createClient();
     return resolveAuthenticatedRole(supabase);

--- a/app/internal-search/employee-result-card.tsx
+++ b/app/internal-search/employee-result-card.tsx
@@ -1,3 +1,6 @@
+/**
+ * Directory search result card; fields shown depend on caller role.
+ */
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -31,6 +34,9 @@ function Field({ label, value }: FieldProps) {
     );
 }
 
+/**
+ * Renders the Employee Result Card UI.
+ */
 export function EmployeeResultCard({ employee }: Props) {
     const fullName = `${employee.first_name ?? ""} ${employee.last_name ?? ""}`.trim() || "Unknown";
     const payRate = hasPayInfo(employee) && employee.pay_rate != null

--- a/app/internal-search/page.tsx
+++ b/app/internal-search/page.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+/**
+ * Internal employee directory search UI with role-tiered result cards.
+ */
 import { useEffect, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -33,6 +36,9 @@ function createSearchState(sessionKey: string): SearchState {
   };
 }
 
+/**
+ * Default export: External Employee Search Page.
+ */
 export default function ExternalEmployeeSearchPage() {
   const { role, userId } = useAuthenticatedRole();
   const sessionKey = userId ?? "visitor";

--- a/app/internal-search/use-authenticated-role.ts
+++ b/app/internal-search/use-authenticated-role.ts
@@ -1,5 +1,8 @@
 'use client';
 
+/**
+ * Client hook that loads the signed-in profiles.role for directory column gating.
+ */
 import { useEffect, useState } from "react";
 import { createClient } from "@/utils/supabase/client";
 import { getAuthenticatedUserRoleAction } from "./actions";
@@ -9,6 +12,9 @@ type AuthenticatedRoleState = {
     userId: string | null;
 };
 
+/**
+ * Hook: use Authenticated Role.
+ */
 export function useAuthenticatedRole(): AuthenticatedRoleState {
     const [authState, setAuthState] = useState<AuthenticatedRoleState>({
         role: 'visitor',

--- a/app/internal-search/utils.ts
+++ b/app/internal-search/utils.ts
@@ -1,5 +1,11 @@
+/**
+ * Display helpers for directory search results (location, role, initials, field presence).
+ */
 import type { EmployeeWithProfile } from "@/lib/supabase/employee";
 
+/**
+ * Format Location.
+ */
 export function formatLocation(employee: EmployeeWithProfile) {
     const pieces = [
         ('address_line' in employee ? employee.address_line : null),
@@ -11,29 +17,44 @@ export function formatLocation(employee: EmployeeWithProfile) {
     return pieces.length > 0 ? pieces.join(", ") : "Location not available";
 }
 
+/**
+ * Has Pay Info.
+ */
 export function hasPayInfo(
     employee: EmployeeWithProfile,
 ): employee is EmployeeWithProfile & { pay_rate: number } {
     return 'pay_rate' in employee;
 }
 
+/**
+ * Has Address Info.
+ */
 export function hasAddressInfo(
     employee: EmployeeWithProfile,
 ): employee is EmployeeWithProfile & { address_line: string } {
     return 'address_line' in employee;
 }
 
+/**
+ * Has Pay Frequency.
+ */
 export function hasPayFrequency(
     employee: EmployeeWithProfile,
 ): employee is EmployeeWithProfile & { pay_frequency: string | null } {
     return 'pay_frequency' in employee;
 }
 
+/**
+ * Capitalize Role.
+ */
 export function capitalizeRole(role: string | null): string {
     const normalized = role?.toLowerCase() ?? 'visitor';
     return normalized.charAt(0).toUpperCase() + normalized.slice(1);
 }
 
+/**
+ * Get Initials.
+ */
 export function getInitials(firstName: string | null, lastName: string | null): string {
     const first = firstName?.trim().charAt(0) ?? '';
     const last = lastName?.trim().charAt(0) ?? '';

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,6 @@
+/**
+ * Root layout: theme + React Query providers and NavbarWrapper around all pages.
+ */
 import "./globals.css";
 import type { Metadata } from "next";
 import Providers from "./providers";
@@ -12,6 +15,9 @@ export const metadata: Metadata = {
   }
 };
 
+/**
+ * Default export: Root Layout.
+ */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
 
   return (

--- a/app/manager/benefits/page.tsx
+++ b/app/manager/benefits/page.tsx
@@ -1,3 +1,6 @@
+/**
+ * Manager benefits admin page (company + optional catalogs).
+ */
 import SummaryCards from "@/components/manager/summary-cards/SummaryCards"
 import CompanyBenefitsGrid from "@/components/manager/company-benefits/CompanyBenefits"
 import OptionalBenefitsGrid from "@/components/manager/optional-benefits/OptionalBenefits"
@@ -6,6 +9,9 @@ import { getAverageBenefitDeductions } from "@/lib/supabase/payroll"
 
 export const dynamic = "force-dynamic"
 
+/**
+ * Default export: Benefits Page.
+ */
 export default async function BenefitsPage() {
     const results = await Promise.allSettled([
         getCompanyBenefitsCount(),

--- a/app/manager/dashboard/page.tsx
+++ b/app/manager/dashboard/page.tsx
@@ -1,9 +1,15 @@
+/**
+ * Manager dashboard shell (force-dynamic) composing stat and grid cards.
+ */
 import ManagerStatCards from "@/components/manager/stat-cards/Statcards"
 import GridContent from "@/components/manager/grid-content/GridContent"
 import { getActiveEmployeesCount, getTotalAnnualPayroll } from "@/lib/supabase/employee"
 
 export const dynamic = "force-dynamic"
 
+/**
+ * Default export: Manager Dashboard Page.
+ */
 export default async function ManagerDashboardPage() {
     const results = await Promise.allSettled([
         getActiveEmployeesCount(),

--- a/app/manager/employee-table/__tests__/EmployeeTable.test.tsx
+++ b/app/manager/employee-table/__tests__/EmployeeTable.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for app/manager/employee-table.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -485,14 +488,14 @@ describe('EmployeeTable Component', () => {
                 expect(addButton).toBeInTheDocument();
             });
 
-            // TODO: Implement dialog trigger verification
+            // TODO(#187): Implement dialog trigger verification
             // Requires: userEvent.click(addButton) + verify dialog content
         });
     });
 
     describe('Error Handling', () => {
         it.skip('displays error message when employee operations fail', async () => {
-            // TODO: Requires mocking failed API call, triggering error state
+            // TODO(#187): Requires mocking failed API call, triggering error state
             mockGetEmployees.mockResolvedValue([
                 makeEmployee({ id: 'emp-1' }),
             ]);

--- a/app/manager/employee-table/page.tsx
+++ b/app/manager/employee-table/page.tsx
@@ -1,5 +1,9 @@
 'use client'
 
+/**
+ * Manager employee table: list/add/edit/delete with dialogs.
+ * SECURITY: exposes pay rates and employee PII to managers.
+ */
 import { useMemo, useState, useEffect } from "react";
 import { ColumnDef } from "@tanstack/react-table";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
@@ -173,6 +177,9 @@ function ActionsCell({ employee, onUpdate, onDelete, onError }: {
   );
 }
 
+/**
+ * Default export: Employee Table.
+ */
 export default function EmployeeTable() {
   const {
     firstName, setFirstName,

--- a/app/manager/payroll-records-table/__tests__/PayrollRecords.test.tsx
+++ b/app/manager/payroll-records-table/__tests__/PayrollRecords.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for app/manager/payroll-records-table.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/app/manager/payroll-records-table/page.tsx
+++ b/app/manager/payroll-records-table/page.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+/**
+ * Manager payroll records table for completed run line items.
+ * SECURITY: shows per-employee gross/net/tax figures.
+ */
 import { useMemo, useState, useEffect } from "react";
 import { ColumnDef } from "@tanstack/react-table";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
@@ -26,6 +30,9 @@ function formatHours(value: number | null): string {
   return value == null ? "—" : String(value);
 }
 
+/**
+ * Default export: Payroll Table.
+ */
 export default function PayrollTable() {
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");

--- a/app/manager/payroll-records-table/types.ts
+++ b/app/manager/payroll-records-table/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Column/row types for the manager payroll records table.
+ */
 export type PayrollRecordType = {
     id: string;
     employee_id: string | null;

--- a/app/manager/payroll-status/page.tsx
+++ b/app/manager/payroll-status/page.tsx
@@ -1,5 +1,9 @@
 'use client'
 
+/**
+ * Manager payroll status/run UI: trigger runPayroll for a pay period.
+ * SECURITY: initiates payroll mutation affecting compensation records.
+ */
 import { Suspense } from 'react'
 import { Card, CardContent } from "@/components/ui/card"
 import { Spinner } from "@/components/ui/spinner";
@@ -18,6 +22,9 @@ import { runPayroll } from "@/lib/supabase/payroll-actions";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState, useRef } from "react";
 
+/**
+ * Renders the Payroll Section UI.
+ */
 export function PayrollSection({ title, value, icon, color }: PayrollSectionProps) {
     return (
         <>
@@ -30,6 +37,9 @@ export function PayrollSection({ title, value, icon, color }: PayrollSectionProp
     )
 }
 
+/**
+ * Renders the Status Card UI.
+ */
 export function StatusCard({ text, icon, color, children }: StatusCardProps) {
     return (
         <Card className={`border-2 ${color.border} ${color.bg}`}>
@@ -183,6 +193,9 @@ function PayrollStatusContent() {
     )
 }
 
+/**
+ * Default export: Payroll Status Page.
+ */
 export default function PayrollStatusPage() {
     return (
         <Suspense fallback={

--- a/app/manager/payroll-status/types.ts
+++ b/app/manager/payroll-status/types.ts
@@ -1,5 +1,11 @@
+/**
+ * Prop types for payroll status section/status cards.
+ */
 import type React from "react";
 
+/**
+ * StatusCardProps type/interface.
+ */
 export interface StatusCardProps {
     text: {
         title: string
@@ -13,6 +19,9 @@ export interface StatusCardProps {
     children?: React.ReactNode
 }
 
+/**
+ * PayrollSectionProps type/interface.
+ */
 export interface PayrollSectionProps {
     title: string
     value: string | number

--- a/app/navbar-wrapper.tsx
+++ b/app/navbar-wrapper.tsx
@@ -1,8 +1,15 @@
 "use client";
+/**
+ * Chooses Manager vs Employee navbar from the URL path; hidden on login and internal-search.
+ * Temporary path heuristic — see TODO(#186).
+ */
 import { usePathname } from "next/navigation";
 import { ManagerNavbar } from "@/components/ui/navbars/manager-navbar";
 import { EmployeeNavbar } from "@/components/ui/navbars/employee-navbar";
 
+/**
+ * Renders ManagerNavbar or EmployeeNavbar from pathname, or null on / and /internal-search.
+ */
 export function NavbarWrapper() {
     const pathname = usePathname();
 
@@ -10,8 +17,7 @@ export function NavbarWrapper() {
     // The external search page has its own navbar.
     if (pathname === "/" || pathname === "/internal-search") return null;
 
-    // TODO (backend team): This is a temporary solution. We should ideally determine the user's role and render the appropriate navbar based on that,
-    // rather than relying on the URL path. 
+    // TODO(#186): Path-based navbar is temporary — determine the user's role and render the matching navbar instead of relying on the URL path.
     if (pathname.startsWith("/manager")) {
         return <ManagerNavbar />;
     }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,8 @@
 'use client'
+/**
+ * Login page: email/password sign-in, then routes by profiles.role (MANAGER/EMPLOYEE).
+ * SECURITY: auth credentials handled by Supabase Auth — never log passwords.
+ */
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -18,6 +22,9 @@ import Image from "next/image";
 import { createClient } from "@/utils/supabase/client";
 import SplitText from "@/components/SplitText";
 
+/**
+ * Default export: Login Page.
+ */
 export default function LoginPage() {
   const supabase = createClient();
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,8 +1,14 @@
 'use client';
 
+/**
+ * App-wide React Query (QueryClient) provider.
+ */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode, useState } from "react";
 
+/**
+ * Default export: Providers.
+ */
 export default function Providers({ children }: { children: ReactNode }) {
     const [queryClient] = useState(() => new QueryClient());
 

--- a/app/theme-provider.tsx
+++ b/app/theme-provider.tsx
@@ -1,8 +1,14 @@
 "use client"
 
+/**
+ * next-themes ThemeProvider wrapper for light/dark/system.
+ */
 import * as React from "react"
 import { ThemeProvider as NextThemesProvider } from "next-themes"
 
+/**
+ * Renders the Theme Provider UI.
+ */
 export function ThemeProvider({
     children,
     ...props

--- a/components/SplitText.tsx
+++ b/components/SplitText.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+/**
+ * Shared UI component: SplitText.
+ */
 import React, { useRef, useEffect, useState } from 'react';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
@@ -8,6 +11,9 @@ import { useGSAP } from '@gsap/react';
 
 gsap.registerPlugin(ScrollTrigger, GSAPSplitText, useGSAP);
 
+/**
+ * SplitTextProps type/interface.
+ */
 export interface SplitTextProps {
   text: string;
   className?: string;

--- a/components/animate-ui/components/buttons/button.tsx
+++ b/components/animate-ui/components/buttons/button.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+/**
+ * animate-ui motion primitive/component: button.
+ */
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -9,6 +12,9 @@ import {
 } from '@/components/animate-ui/primitives/buttons/button';
 import { cn } from '@/lib/utils';
 
+/**
+ * Button Variants.
+ */
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[box-shadow,_color,_background-color,_border-color,_outline-color,_text-decoration-color,_fill,_stroke] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
@@ -45,6 +51,9 @@ const buttonVariants = cva(
 
 type ButtonProps = ButtonPrimitiveProps & VariantProps<typeof buttonVariants>;
 
+/**
+ * Button UI primitive (exported from this module).
+ */
 function Button({ className, variant, size, ...props }: ButtonProps) {
   return (
     <ButtonPrimitive

--- a/components/animate-ui/components/buttons/icon.tsx
+++ b/components/animate-ui/components/buttons/icon.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+/**
+ * animate-ui motion primitive/component: icon.
+ */
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -13,6 +16,9 @@ import {
   ParticlesEffect,
 } from '@/components/animate-ui/primitives/effects/particles';
 
+/**
+ * Button Variants.
+ */
 const buttonVariants = cva(
   "flex items-center justify-center rounded-md transition-[box-shadow,_color,_background-color,_border-color,_outline-color,_text-decoration-color,_fill,_stroke] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
@@ -50,6 +56,9 @@ type IconButtonProps = Omit<ButtonPrimitiveProps, 'asChild'> &
     children?: React.ReactNode;
   };
 
+/**
+ * IconButton UI primitive (exported from this module).
+ */
 function IconButton({
   className,
   onClick,

--- a/components/animate-ui/primitives/animate/slot.tsx
+++ b/components/animate-ui/primitives/animate/slot.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+/**
+ * animate-ui motion primitive/component: slot.
+ */
 /* eslint-disable react-hooks/static-components -- Dynamic asChild slots wrap arbitrary child element types; wrappers are cached by element type so identity stays stable. */
 
 import * as React from 'react';
@@ -71,6 +74,9 @@ function mergeProps<T extends HTMLElement>(
   return merged;
 }
 
+/**
+ * Slot UI primitive (exported from this module).
+ */
 function Slot<T extends HTMLElement = HTMLElement>({
   children,
   ref,

--- a/components/animate-ui/primitives/buttons/button.tsx
+++ b/components/animate-ui/primitives/buttons/button.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+/**
+ * animate-ui motion primitive/component: button.
+ */
 import * as React from 'react';
 import { motion, type HTMLMotionProps } from 'motion/react';
 
@@ -12,6 +15,9 @@ type ButtonProps = WithAsChild<
   }
 >;
 
+/**
+ * Button UI primitive (exported from this module).
+ */
 function Button({
   hoverScale = 1.05,
   tapScale = 0.95,

--- a/components/animate-ui/primitives/effects/particles.tsx
+++ b/components/animate-ui/primitives/effects/particles.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+/**
+ * animate-ui motion primitive/component: particles.
+ */
 import * as React from 'react';
 import { motion, AnimatePresence, type HTMLMotionProps } from 'motion/react';
 
@@ -28,6 +31,9 @@ type ParticlesProps = WithAsChild<
   } & UseIsInViewOptions
 >;
 
+/**
+ * Particles UI primitive (exported from this module).
+ */
 function Particles({
   ref,
   animate = true,
@@ -72,6 +78,9 @@ type ParticlesEffectProps = Omit<HTMLMotionProps<'div'>, 'children'> & {
   delay?: number;
 };
 
+/**
+ * ParticlesEffect UI primitive (exported from this module).
+ */
 function ParticlesEffect({
   side = 'top',
   align = 'center',

--- a/components/animate-ui/primitives/radix/toggle.tsx
+++ b/components/animate-ui/primitives/radix/toggle.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+/**
+ * animate-ui motion primitive/component: toggle.
+ */
 import * as React from 'react';
 import { Toggle as TogglePrimitive } from 'radix-ui';
 import { motion, AnimatePresence, type HTMLMotionProps } from 'motion/react';
@@ -22,6 +25,9 @@ type ToggleProps = Omit<
 > &
   HTMLMotionProps<'button'>;
 
+/**
+ * Toggle UI primitive (exported from this module).
+ */
 function Toggle({
   pressed,
   defaultPressed,
@@ -56,6 +62,9 @@ function Toggle({
 
 type ToggleHighlightProps = HTMLMotionProps<'div'>;
 
+/**
+ * ToggleHighlight UI primitive (exported from this module).
+ */
 function ToggleHighlight({ style, ...props }: ToggleHighlightProps) {
   const { isPressed, disabled } = useToggle();
 
@@ -80,6 +89,9 @@ function ToggleHighlight({ style, ...props }: ToggleHighlightProps) {
 
 type ToggleItemProps = HTMLMotionProps<'div'>;
 
+/**
+ * ToggleItem UI primitive (exported from this module).
+ */
 function ToggleItem({ style, ...props }: ToggleItemProps) {
   const { isPressed, disabled } = useToggle();
 

--- a/components/employee/check-form/CheckPDF.tsx
+++ b/components/employee/check-form/CheckPDF.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+/**
+ * React-PDF paystub/check document for employee downloads.
+ * SECURITY: renders compensation, address, and synthetic YTD/SSN fields — treat as PII.
+ */
 import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
 import type { CheckData } from "@/app/employee/paystubs/types";
 
@@ -149,6 +153,10 @@ function formatDate(dateStr: string): string {
 	});
 }
 
+/**
+ * Renders a multi-page paystub PDF from CheckData.
+ * SECURITY: document includes net pay, address, and synthetic SSN/YTD — do not log `data`.
+ */
 export function CheckPDF({ data }: { data: CheckData }) {
 	const ytdMultiplier = data.grossPay > 0 ? data.ytdGross / data.grossPay : 1;
 

--- a/components/employee/company-benefits-cards/CompanyBenefits.tsx
+++ b/components/employee/company-benefits-cards/CompanyBenefits.tsx
@@ -1,11 +1,17 @@
 "use client"
 
+/**
+ * Employee-facing UI: CompanyBenefits.
+ */
 import { createElement, useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { BENEFIT_ICONS } from "../constants"
 import { getCompanyBenefits } from "@/lib/supabase/benefits"
 
+/**
+ * Default export: Company Benefits Card.
+ */
 export default function CompanyBenefitsCard() {
     const [company_benefits, setCompanyBenefits] = useState<Awaited<ReturnType<typeof getCompanyBenefits>>>([]);
     const [isLoading, setIsLoading] = useState(true);

--- a/components/employee/constants.ts
+++ b/components/employee/constants.ts
@@ -1,3 +1,6 @@
+/**
+ * Employee-facing UI: constants.
+ */
 import type { LucideIcon } from "lucide-react";
 import {
     BadgeCheck,
@@ -8,6 +11,9 @@ import {
     Stethoscope,
 } from "lucide-react"
 
+/**
+ * Benefit type/interface.
+ */
 export type Benefit = {
     title: string
     description: string

--- a/components/employee/grid-content/GridContent.tsx
+++ b/components/employee/grid-content/GridContent.tsx
@@ -1,9 +1,15 @@
+/**
+ * Employee-facing UI: GridContent.
+ */
 import WeeklyHoursCardBreakdown from "./grid-cards/weekly-hours-card"
 import YTDEarningsCard from "./grid-cards/ytd-earnings-card"
 import RecentTimesheetsCard from "./grid-cards/recent-timesheets-card"
 import type { GridContentProps } from "./grid-cards/types"
 import QuickStatsCard from "./grid-cards/quick-stats-card"
 
+/**
+ * Default export: Grid Content.
+ */
 export default function GridContent({ timesheets, setTimesheets, hoursByDay, setHoursByDay, chartConfig }: GridContentProps) {
     return (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/components/employee/grid-content/grid-cards/quick-stats-card.tsx
+++ b/components/employee/grid-content/grid-cards/quick-stats-card.tsx
@@ -1,6 +1,12 @@
+/**
+ * Employee-facing UI: quick-stats-card.
+ */
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Briefcase, Calendar, Heart, Building2 } from "lucide-react"
 
+/**
+ * Default export: Quick Stats Card.
+ */
 export default function QuickStatsCard() {
     return (
         <Card className="shadow-sm">

--- a/components/employee/grid-content/grid-cards/recent-timesheets-card.tsx
+++ b/components/employee/grid-content/grid-cards/recent-timesheets-card.tsx
@@ -1,4 +1,7 @@
 'use client'
+/**
+ * Employee-facing UI: recent-timesheets-card.
+ */
 import { useState } from "react";
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -11,6 +14,9 @@ import { createTimeEntry } from "@/lib/supabase/time-entries"
 import { getShortDay } from "@/lib/utils"
 import type { RecentTimesheetsCardProps } from "./types"
 
+/**
+ * Default export: Recent Timesheets Card.
+ */
 export default function RecentTimesheetsCard({ timeEntries, setTimesheets, setHoursByDay }: RecentTimesheetsCardProps) {
     const recentEntries = [...(timeEntries || [])]
         .sort((a, b) => b.date.localeCompare(a.date))

--- a/components/employee/grid-content/grid-cards/types.ts
+++ b/components/employee/grid-content/grid-cards/types.ts
@@ -1,11 +1,20 @@
+/**
+ * Employee-facing UI: types.
+ */
 import type { Dispatch, SetStateAction } from "react"
 import type { ChartConfig } from "@/components/ui/chart"
 
+/**
+ * HoursByDay type/interface.
+ */
 export interface HoursByDay {
     day: string;
     hours: number;
 }
 
+/**
+ * TimeEntry type/interface.
+ */
 export interface TimeEntry {
     id: string;
     date: string;
@@ -13,16 +22,25 @@ export interface TimeEntry {
     status: "PENDING" | "APPROVED" | "REJECTED";
 }
 
+/**
+ * QuickActionsCardProps type/interface.
+ */
 export interface QuickActionsCardProps {
     setTimesheets: Dispatch<SetStateAction<TimeEntry[]>>
     setHoursByDay: Dispatch<SetStateAction<HoursByDay[]>>
 }
 
+/**
+ * RecentTimesheetsCardProps type/interface.
+ */
 export interface RecentTimesheetsCardProps {
     timeEntries?: TimeEntry[]
     setTimesheets: Dispatch<SetStateAction<TimeEntry[]>>
     setHoursByDay: Dispatch<SetStateAction<HoursByDay[]>>
 }
+/**
+ * GridContentProps type/interface.
+ */
 export interface GridContentProps {
     timesheets: TimeEntry[]
     setTimesheets: Dispatch<SetStateAction<TimeEntry[]>>

--- a/components/employee/grid-content/grid-cards/weekly-hours-card.tsx
+++ b/components/employee/grid-content/grid-cards/weekly-hours-card.tsx
@@ -1,9 +1,15 @@
 'use client'
+/**
+ * Employee-facing UI: weekly-hours-card.
+ */
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@/components/ui/chart"
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts"
 import type { HoursByDay } from "./types";
 
+/**
+ * Default export: Weekly Hours Card Breakdown.
+ */
 export default function WeeklyHoursCardBreakdown({ chartConfig, hoursByDay }: { chartConfig?: ChartConfig; hoursByDay?: HoursByDay[] }) {
     if (!chartConfig || !hoursByDay) {
         return (

--- a/components/employee/grid-content/grid-cards/ytd-earnings-card.tsx
+++ b/components/employee/grid-content/grid-cards/ytd-earnings-card.tsx
@@ -1,3 +1,6 @@
+/**
+ * Employee-facing UI: ytd-earnings-card.
+ */
 import { Card, CardContent } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { TrendingUp } from "lucide-react"
@@ -10,6 +13,9 @@ const DEDUCTIONS_YTD = GROSS_YTD - NET_YTD
 const AVG_PER_CHECK = NET_YTD / COMPLETED_PERIODS
 const progressPct = Math.round((COMPLETED_PERIODS / TOTAL_PAY_PERIODS) * 100)
 
+/**
+ * Default export: YTDEarnings Card.
+ */
 export default function YTDEarningsCard() {
     return (
         <Card className="shadow-sm overflow-hidden">

--- a/components/employee/important-info-card/ImportantInfoCard.tsx
+++ b/components/employee/important-info-card/ImportantInfoCard.tsx
@@ -1,6 +1,12 @@
+/**
+ * Employee-facing UI: ImportantInfoCard.
+ */
 import { Card, CardContent } from "@/components/ui/card"
 import { Info } from "lucide-react"
 
+/**
+ * Default export: Important Info Card.
+ */
 export default function ImportantInfoCard() {
     return (
 

--- a/components/employee/optional-benefits-cards/OptionalBenefits.tsx
+++ b/components/employee/optional-benefits-cards/OptionalBenefits.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+/**
+ * Employee-facing UI: OptionalBenefits.
+ */
 import { createElement, useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { BENEFIT_ICONS } from "../constants"
@@ -10,6 +13,9 @@ import { Lock } from "lucide-react"
 import type { OptionalBenefitsCardProps } from "../types"
 import { getOptionalBenefits, upsertEmployeeBenefit } from "@/lib/supabase/benefits"
 
+/**
+ * Default export: Optional Benefits Card.
+ */
 export default function OptionalBenefitsCard({ selected_benefits, set_selected_benefits, eligibility }: OptionalBenefitsCardProps) {
     const ineligible = eligibility !== undefined && !eligibility.eligible && !eligibility.loading
     const [optional_benefits, setOptionalBenefits] = useState<Awaited<ReturnType<typeof getOptionalBenefits>>>([]);

--- a/components/employee/optional-benefits-cards/__tests__/OptionalBenefitsCard.test.tsx
+++ b/components/employee/optional-benefits-cards/__tests__/OptionalBenefitsCard.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for components/employee/optional-benefits-cards.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Tables } from '@/lib/interfaces/database.types';

--- a/components/employee/progress-bar/ProgressBar.tsx
+++ b/components/employee/progress-bar/ProgressBar.tsx
@@ -1,7 +1,13 @@
+/**
+ * Employee-facing UI: ProgressBar.
+ */
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import type { ProgressBarCardProps } from "./types"
 
+/**
+ * Default export: Progress Bar Card.
+ */
 export default function ProgressBarCard({ company_count, optional_count, selected_count, pct_company }: ProgressBarCardProps) {
     const clampedPct = Math.max(0, Math.min(100, pct_company));
 

--- a/components/employee/progress-bar/types.ts
+++ b/components/employee/progress-bar/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Employee-facing UI: types.
+ */
 export interface ProgressBarCardProps {
     company_count: number;
     optional_count: number;

--- a/components/employee/stat_cards/StatCards.tsx
+++ b/components/employee/stat_cards/StatCards.tsx
@@ -1,3 +1,6 @@
+/**
+ * Employee-facing UI: StatCards.
+ */
 import {
     Clock,
     DollarSign,
@@ -6,6 +9,9 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { EmployeeStatCardProps, HoursByDayProps } from "./types"
 
+/**
+ * Renders the Employee Stat Card UI.
+ */
 export function EmployeeStatCard({ title, icon, value, description }: EmployeeStatCardProps) {
     return (
         <Card>
@@ -21,6 +27,9 @@ export function EmployeeStatCard({ title, icon, value, description }: EmployeeSt
     )
 }
 
+/**
+ * Default export: Employee Stat Cards.
+ */
 export default function EmployeeStatCards({ hoursThisWeek, weeklyTarget }: HoursByDayProps) {
     return (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-4 mt-4">

--- a/components/employee/stat_cards/types.ts
+++ b/components/employee/stat_cards/types.ts
@@ -1,5 +1,11 @@
+/**
+ * Employee-facing UI: types.
+ */
 import type { ReactNode } from "react";
 
+/**
+ * EmployeeStatCardProps type/interface.
+ */
 export interface EmployeeStatCardProps {
     title: string;
     icon?: ReactNode;
@@ -7,6 +13,9 @@ export interface EmployeeStatCardProps {
     description?: string;
 }
 
+/**
+ * HoursByDayProps type/interface.
+ */
 export interface HoursByDayProps {
     hoursThisWeek: string | number;
     weeklyTarget: string | number;

--- a/components/employee/summary-cards/SummaryCards.tsx
+++ b/components/employee/summary-cards/SummaryCards.tsx
@@ -1,8 +1,14 @@
+/**
+ * Employee-facing UI: SummaryCards.
+ */
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { SummaryCardProps, SummaryCardsProps } from "../types"
 import { DollarSign } from "lucide-react"
 
 
+/**
+ * Renders the Summary Card UI.
+ */
 export function SummaryCard({ title, value, color, description }: SummaryCardProps) {
     return (
         <div className="rounded-md border bg-background dark:bg-blue-950/40 border-none p-4 text-center">
@@ -13,6 +19,9 @@ export function SummaryCard({ title, value, color, description }: SummaryCardPro
     )
 }
 
+/**
+ * Default export: Summary Cards.
+ */
 export default function SummaryCards({ company_count, optional_count, monthly_deduction }: SummaryCardsProps) {
     return (
         <div className="mb-8 mt-4">

--- a/components/employee/summary-cards/__tests__/SummaryCards.test.tsx
+++ b/components/employee/summary-cards/__tests__/SummaryCards.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for components/employee/summary-cards.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 

--- a/components/employee/types.ts
+++ b/components/employee/types.ts
@@ -1,6 +1,12 @@
+/**
+ * Employee-facing UI: types.
+ */
 import React from "react"
 import type { EligibilityResult } from "@/lib/benefits/eligibility"
 
+/**
+ * SummaryCardProps type/interface.
+ */
 export interface SummaryCardProps {
     title: string;
     value: string | number;
@@ -8,12 +14,18 @@ export interface SummaryCardProps {
     description: string;
 }
 
+/**
+ * SummaryCardsProps type/interface.
+ */
 export interface SummaryCardsProps {
     company_count: number;
     optional_count: number;
     monthly_deduction?: number;
 }
 
+/**
+ * OptionalBenefitsCardProps type/interface.
+ */
 export interface OptionalBenefitsCardProps {
     selected_benefits: Record<string, boolean>;
     set_selected_benefits: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;

--- a/components/manager/company-benefits/CompanyBenefits.tsx
+++ b/components/manager/company-benefits/CompanyBenefits.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+/**
+ * Manager-facing UI: CompanyBenefits.
+ */
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Plus, CircleMinus, CheckCircle2 } from "lucide-react";
@@ -23,6 +26,9 @@ import {
 } from "@/components/ui/dialog";
 import { useAddBenefit } from "@/hooks/use-add-benefit";
 
+/**
+ * Renders the Company Benefit Details UI.
+ */
 export function CompanyBenefitDetails({ title, value }: BenefitDetailsProps) {
     return (
         <div className="flex items-center justify-between">
@@ -32,6 +38,9 @@ export function CompanyBenefitDetails({ title, value }: BenefitDetailsProps) {
     )
 }
 
+/**
+ * Default export: Company Benefits Grid.
+ */
 export default function CompanyBenefitsGrid() {
     const router = useRouter();
     const [company_benefits, setCompanyBenefits] = useState<Awaited<ReturnType<typeof getCompanyBenefits>>>([]);

--- a/components/manager/company-benefits/__tests__/CompanyBenefits.test.tsx
+++ b/components/manager/company-benefits/__tests__/CompanyBenefits.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for components/manager/company-benefits.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { Tables } from '@/lib/interfaces/database.types';
@@ -188,7 +191,7 @@ describe('CompanyBenefitsGrid Component', () => {
         });
 
         it('opens dialog when Add button clicked', async () => {
-            // TODO: Requires userEvent.click + dialog visibility assertion
+            // TODO(#188): Requires userEvent.click + dialog visibility assertion
             mockGetCompanyBenefits.mockResolvedValue([]);
 
             render(<CompanyBenefitsGrid />);
@@ -200,7 +203,7 @@ describe('CompanyBenefitsGrid Component', () => {
         });
 
         it.skip('displays form fields in add dialog', async () => {
-            // TODO: Requires userEvent.click to open dialog + fill form + submit
+            // TODO(#188): Requires userEvent.click to open dialog + fill form + submit
             mockGetCompanyBenefits.mockResolvedValue([]);
 
             render(<CompanyBenefitsGrid />);
@@ -211,7 +214,7 @@ describe('CompanyBenefitsGrid Component', () => {
         });
 
         it.skip('adds new benefit to list after submission', async () => {
-            // TODO: Requires mockAddCompanyBenefit + click + fill + submit + list verification
+            // TODO(#188): Requires mockAddCompanyBenefit + click + fill + submit + list verification
             mockGetCompanyBenefits
                 .mockResolvedValueOnce([])
                 .mockResolvedValueOnce([
@@ -226,7 +229,7 @@ describe('CompanyBenefitsGrid Component', () => {
         });
 
         it('shows success feedback after adding', async () => {
-            // TODO: Requires full add flow + success toast assertion
+            // TODO(#188): Requires full add flow + success toast assertion
             const newBenefit = makeBenefit({ benefit: 'New Benefit' });
             mockGetCompanyBenefits.mockResolvedValue([newBenefit]);
 
@@ -238,7 +241,7 @@ describe('CompanyBenefitsGrid Component', () => {
         });
 
         it.skip('closes dialog after successful addition', async () => {
-            // TODO: Requires click + submit + dialog close verification
+            // TODO(#188): Requires click + submit + dialog close verification
             mockGetCompanyBenefits.mockResolvedValue([]);
 
             render(<CompanyBenefitsGrid />);
@@ -251,7 +254,7 @@ describe('CompanyBenefitsGrid Component', () => {
 
     describe('Edit Company Benefit', () => {
         it.skip('opens edit dialog when benefit card is clicked', async () => {
-            // TODO: Requires click card + dialog visibility assertion
+            // TODO(#188): Requires click card + dialog visibility assertion
             const benefit = makeBenefit({
                 benefit: 'Health Insurance',
             });
@@ -265,7 +268,7 @@ describe('CompanyBenefitsGrid Component', () => {
         });
 
         it.skip('pre-fills edit dialog with current benefit data', async () => {
-            // TODO: Requires click + dialog open + form value verification
+            // TODO(#188): Requires click + dialog open + form value verification
             const benefit = makeBenefit({
                 benefit: 'Health Insurance',
                 description: 'Current coverage',
@@ -283,7 +286,7 @@ describe('CompanyBenefitsGrid Component', () => {
         });
 
         it.skip('updates benefit on save', async () => {
-            // TODO: Requires click benefit card + fill form + submit + mockUpdateBenefit call
+            // TODO(#188): Requires click benefit card + fill form + submit + mockUpdateBenefit call
             const benefit = makeBenefit({ benefit: 'Health Insurance' });
             mockGetCompanyBenefits.mockResolvedValue([benefit]);
             mockUpdateBenefit.mockResolvedValue({ id: benefit.id });
@@ -296,7 +299,7 @@ describe('CompanyBenefitsGrid Component', () => {
         });
 
         it.skip('cancels deletion without removing benefit', async () => {
-            // TODO: Requires click delete + confirm dialog + cancel
+            // TODO(#188): Requires click delete + confirm dialog + cancel
             const benefit = makeBenefit({ benefit: 'Health Insurance' });
             mockGetCompanyBenefits.mockResolvedValue([benefit]);
 
@@ -308,7 +311,7 @@ describe('CompanyBenefitsGrid Component', () => {
         });
 
         it.skip('shows error if deletion fails', async () => {
-            // TODO: Requires click delete + mockDeleteBenefit rejection + error assertion
+            // TODO(#188): Requires click delete + mockDeleteBenefit rejection + error assertion
             const benefit = makeBenefit({ benefit: 'Health Insurance' });
             mockGetCompanyBenefits.mockResolvedValue([benefit]);
             mockDeleteBenefit.mockRejectedValue(new Error('Delete failed'));
@@ -321,7 +324,7 @@ describe('CompanyBenefitsGrid Component', () => {
         });
 
         it.skip('shows loading state during deletion', async () => {
-            // TODO: Requires click delete + loading state assertion
+            // TODO(#188): Requires click delete + loading state assertion
             const benefit = makeBenefit({ benefit: 'Health Insurance' });
             mockGetCompanyBenefits.mockResolvedValue([benefit]);
             mockDeleteBenefit.mockImplementation(() => new Promise(() => { }));

--- a/components/manager/constant.ts
+++ b/components/manager/constant.ts
@@ -1,3 +1,6 @@
+/**
+ * Manager-facing UI: constant.
+ */
 import type { LucideIcon } from "lucide-react";
 import {
     Heart,
@@ -9,6 +12,9 @@ import {
     Info
 } from "lucide-react"
 
+/**
+ * Benefit type/interface.
+ */
 export interface Benefit {
     id: string;
     name: string;

--- a/components/manager/data.ts
+++ b/components/manager/data.ts
@@ -1,3 +1,6 @@
+/**
+ * Manager-facing UI: data.
+ */
 export interface Benefit {
     id: string;
     name: string;

--- a/components/manager/grid-content/GridContent.tsx
+++ b/components/manager/grid-content/GridContent.tsx
@@ -1,3 +1,6 @@
+/**
+ * Manager-facing UI: GridContent.
+ */
 import QuickActionCard from "./grid-cards/quick-actions-card"
 import TeamDistributionPieChart from "./grid-cards/team-distribution"
 import RecentActivityCard from "./grid-cards/recent-activity"
@@ -5,6 +8,9 @@ import PayrollTrendChart from "./grid-cards/payroll-chart"
 import SalaryDistributionBarChart from "./grid-cards/salary-distribution-chart"
 import UpcomingTasksCard from "./grid-cards/upcoming-tasks"
 
+/**
+ * Default export: Grid Content.
+ */
 export default function GridContent() {
     return (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/components/manager/grid-content/grid-cards/payroll-chart.tsx
+++ b/components/manager/grid-content/grid-cards/payroll-chart.tsx
@@ -1,4 +1,7 @@
 "use client"
+/**
+ * Manager-facing UI: payroll-chart.
+ */
 import { CartesianGrid, Line, LineChart, XAxis } from "recharts"
 import {
     Card,
@@ -31,6 +34,9 @@ const chartConfig = {
     },
 } satisfies ChartConfig
 
+/**
+ * Default export: Payroll Trend Chart.
+ */
 export default function PayrollTrendChart() {
     return (
         <Card className="w-full">

--- a/components/manager/grid-content/grid-cards/quick-actions-card.tsx
+++ b/components/manager/grid-content/grid-cards/quick-actions-card.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+/**
+ * Manager-facing UI: quick-actions-card.
+ */
 import { ArrowRight, DollarSign, FileCheck, Heart, UserPlus } from "lucide-react"
 import { Button } from "@/components/animate-ui/components/buttons/button"
 import { Button as BaseButton } from "@/components/ui/button"
@@ -13,6 +16,9 @@ import Link from "next/link"
 import { useAddEmployee } from "@/hooks/use-add-employee"
 import { useState } from "react"
 
+/**
+ * Default export: Quick Action Card.
+ */
 export default function QuickActionCard() {
 
     const {

--- a/components/manager/grid-content/grid-cards/recent-activity.tsx
+++ b/components/manager/grid-content/grid-cards/recent-activity.tsx
@@ -1,3 +1,6 @@
+/**
+ * Manager-facing UI: recent-activity.
+ */
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -9,6 +12,9 @@ const payrollRecords = ([
     { id: "3", employeeName: "Mike Chen", grossPay: 6250.00, taxes: 1562.50, benefitDeductions: 0.00, netPay: 4687.50, status: "approved", date: "2026-01-15" },
 ]);
 
+/**
+ * Default export: Recent Activity Card.
+ */
 export default function RecentActivityCard() {
     return (
         <Card>

--- a/components/manager/grid-content/grid-cards/salary-distribution-chart.tsx
+++ b/components/manager/grid-content/grid-cards/salary-distribution-chart.tsx
@@ -1,4 +1,7 @@
 "use client"
+/**
+ * Manager-facing UI: salary-distribution-chart.
+ */
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts"
 import {
     Card,
@@ -24,6 +27,9 @@ const chartConfig = {
     },
 } satisfies ChartConfig
 
+/**
+ * Default export: Salary Distribution Bar Chart.
+ */
 export default function SalaryDistributionBarChart() {
 
     const [chartData, setChartData] = useState<ChartData[]>([])

--- a/components/manager/grid-content/grid-cards/team-distribution.tsx
+++ b/components/manager/grid-content/grid-cards/team-distribution.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+/**
+ * Manager-facing UI: team-distribution.
+ */
 import { Pie, PieChart, Cell } from "recharts"
 import {
     Card,
@@ -17,6 +20,9 @@ import { getEmployeeByDepartment } from "@/lib/supabase/employee"
 import { useEffect, useState } from "react"
 import { ChartData, chartConfig, DEPARTMENT_COLORS } from "./types"
 
+/**
+ * Default export: Team Distribution Pie Chart.
+ */
 export default function TeamDistributionPieChart() {
 
     const [chartData, setChartData] = useState<ChartData[]>([])

--- a/components/manager/grid-content/grid-cards/types.ts
+++ b/components/manager/grid-content/grid-cards/types.ts
@@ -1,5 +1,11 @@
+/**
+ * Manager-facing UI: types.
+ */
 import { type ChartConfig } from "@/components/ui/chart"
 
+/**
+ * TaskCardProps type/interface.
+ */
 export interface TaskCardProps {
     title: string
     description: string
@@ -10,17 +16,26 @@ export interface TaskCardProps {
         text: string
     }
 }
+/**
+ * ChartData type/interface.
+ */
 export interface ChartData {
     name: string;
     value: number;
 }
 
+/**
+ * Chart Config.
+ */
 export const chartConfig = {
     department: {
         label: "Employees by Department",
     },
 } satisfies ChartConfig
 
+/**
+ * DEPARTMENT COLORS.
+ */
 export const DEPARTMENT_COLORS = [
     "var(--chart-1)",
     "var(--chart-2)",

--- a/components/manager/grid-content/grid-cards/upcoming-tasks.tsx
+++ b/components/manager/grid-content/grid-cards/upcoming-tasks.tsx
@@ -1,7 +1,13 @@
+/**
+ * Manager-facing UI: upcoming-tasks.
+ */
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card"
 import { Calendar, FileCheck, Heart } from "lucide-react"
 import { TaskCardProps } from "./types"
 
+/**
+ * Renders the Task Card UI.
+ */
 export function TaskCard({ title, description, icon, color }: TaskCardProps) {
     return (
         <div className={`flex items-start gap-3 p-3 rounded-lg border ${color.bg} ${color.border} transition-colors`}>
@@ -14,6 +20,9 @@ export function TaskCard({ title, description, icon, color }: TaskCardProps) {
     )
 }
 
+/**
+ * Default export: Upcoming Tasks Card.
+ */
 export default function UpcomingTasksCard() {
     return (
         <Card>

--- a/components/manager/optional-benefits/OptionalBenefits.tsx
+++ b/components/manager/optional-benefits/OptionalBenefits.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+/**
+ * Manager-facing UI: OptionalBenefits.
+ */
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
@@ -22,6 +25,9 @@ import {
 } from "@/components/ui/dialog";
 import { useAddBenefit } from "@/hooks/use-add-benefit";
 
+/**
+ * Renders the Optional Benefit Details UI.
+ */
 export function OptionalBenefitDetails({ title, value }: BenefitDetailsProps) {
     return (
         <div className="flex items-center justify-between">
@@ -31,6 +37,9 @@ export function OptionalBenefitDetails({ title, value }: BenefitDetailsProps) {
     )
 }
 
+/**
+ * Default export: Optional Benefits Grid.
+ */
 export default function OptionalBenefitsGrid() {
     const router = useRouter();
     const [optional_benefits, setOptionalBenefits] = useState<Awaited<ReturnType<typeof getOptionalBenefits>>>([]);

--- a/components/manager/optional-benefits/__tests__/OptionalBenefits.test.tsx
+++ b/components/manager/optional-benefits/__tests__/OptionalBenefits.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for components/manager/optional-benefits.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { Tables } from '@/lib/interfaces/database.types';
@@ -194,7 +197,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it('opens dialog when Add button clicked', async () => {
-            // TODO: Requires userEvent.click + dialog visibility assertion
+            // TODO(#189): Requires userEvent.click + dialog visibility assertion
             mockGetOptionalBenefits.mockResolvedValue([]);
 
             render(<OptionalBenefitsGrid />);
@@ -206,7 +209,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('displays form fields in add dialog', async () => {
-            // TODO: Requires click + dialog fill + submit
+            // TODO(#189): Requires click + dialog fill + submit
             mockGetOptionalBenefits.mockResolvedValue([]);
 
             render(<OptionalBenefitsGrid />);
@@ -217,7 +220,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('requires monthly cost field for optional benefits', async () => {
-            // TODO: Requires form validation testing
+            // TODO(#189): Requires form validation testing
             mockGetOptionalBenefits.mockResolvedValue([]);
 
             render(<OptionalBenefitsGrid />);
@@ -228,7 +231,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('adds new optional benefit to list after submission', async () => {
-            // TODO: Requires click + fill + submit + mockCreate call verification
+            // TODO(#189): Requires click + fill + submit + mockCreate call verification
             mockGetOptionalBenefits
                 .mockResolvedValueOnce([])
                 .mockResolvedValueOnce([
@@ -243,7 +246,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('shows success feedback after adding', async () => {
-            // TODO: Requires full add flow + success toast assertion
+            // TODO(#189): Requires full add flow + success toast assertion
             const newBenefit = makeBenefit({ benefit: 'New Optional', monthly_cost: 30 });
             mockGetOptionalBenefits.mockResolvedValue([newBenefit]);
 
@@ -255,7 +258,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('closes dialog after successful addition', async () => {
-            // TODO: Requires click + submit + dialog close verification
+            // TODO(#189): Requires click + submit + dialog close verification
             mockGetOptionalBenefits.mockResolvedValue([]);
 
             render(<OptionalBenefitsGrid />);
@@ -268,7 +271,7 @@ describe('OptionalBenefitsGrid Component', () => {
 
     describe('Edit Optional Benefit', () => {
         it.skip('opens edit dialog when benefit card is clicked', async () => {
-            // TODO: Requires click + dialog visibility assertion
+            // TODO(#189): Requires click + dialog visibility assertion
             const benefit = makeBenefit({
                 benefit: 'Life Insurance',
             });
@@ -282,7 +285,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('pre-fills edit dialog with current benefit data', async () => {
-            // TODO: Requires click + form value verification
+            // TODO(#189): Requires click + form value verification
             const benefit = makeBenefit({
                 benefit: 'Life Insurance',
                 description: 'Current coverage',
@@ -301,7 +304,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('updates benefit on save', async () => {
-            // TODO: Requires click + fill + submit + mockUpdateBenefit call
+            // TODO(#189): Requires click + fill + submit + mockUpdateBenefit call
             const benefit = makeBenefit({ benefit: 'Life Insurance', monthly_cost: 25 });
             mockGetOptionalBenefits.mockResolvedValue([benefit]);
             mockUpdateBenefit.mockResolvedValue({ id: benefit.id });
@@ -314,7 +317,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('reflects updates immediately in list', async () => {
-            // TODO: Requires update flow + DOM verification
+            // TODO(#189): Requires update flow + DOM verification
             const benefit = makeBenefit({ benefit: 'Life Insurance', monthly_cost: 25 });
             mockGetOptionalBenefits.mockResolvedValue([benefit]);
 
@@ -326,7 +329,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('updates monthly cost when edited', async () => {
-            // TODO: Requires edit flow + cost verification
+            // TODO(#189): Requires edit flow + cost verification
             const benefit = makeBenefit({ monthly_cost: 25 });
             mockGetOptionalBenefits.mockResolvedValue([benefit]);
 
@@ -340,7 +343,7 @@ describe('OptionalBenefitsGrid Component', () => {
 
     describe('Delete Optional Benefit', () => {
         it.skip('shows delete button on each benefit', async () => {
-            // TODO: Requires delete button presence check
+            // TODO(#189): Requires delete button presence check
             const benefit = makeBenefit({ benefit: 'Life Insurance' });
             mockGetOptionalBenefits.mockResolvedValue([benefit]);
 
@@ -363,7 +366,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('confirms deletion and removes benefit', async () => {
-            // TODO: Requires click delete + confirm dialog + list verification
+            // TODO(#189): Requires click delete + confirm dialog + list verification
             const benefit = makeBenefit({ id: 'b1', benefit: 'Life Insurance' });
             mockGetOptionalBenefits
                 .mockResolvedValueOnce([benefit])
@@ -508,7 +511,7 @@ describe('OptionalBenefitsGrid Component', () => {
         });
 
         it.skip('displays benefit tags correctly', async () => {
-            // TODO: Component uses tag for icon lookup, not text display. Tag is not rendered as text.
+            // TODO(#189): Component uses tag for icon lookup, not text display. Tag is not rendered as text.
             // This test should verify icon rendering instead of text.
             const benefits = [
                 makeBenefit({ tag: 'Life' }),

--- a/components/manager/stat-cards/Statcards.tsx
+++ b/components/manager/stat-cards/Statcards.tsx
@@ -1,8 +1,14 @@
+/**
+ * Manager-facing UI: Statcards.
+ */
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { ManagerStatCardProps, ManagerStatCardsProps } from "./types";
 import { Users, Clock, DollarSign } from "lucide-react";
 import { formatCurrency } from "@/utils/formatCurrency";
 
+/**
+ * Renders the Manager Stat Card UI.
+ */
 export function ManagerStatCard({ title, icon, value, description }: ManagerStatCardProps) {
     return (
         <Card>
@@ -21,6 +27,9 @@ export function ManagerStatCard({ title, icon, value, description }: ManagerStat
     )
 }
 
+/**
+ * Default export: Manager Stat Cards.
+ */
 export default function ManagerStatCards({ totalEmployees, totalAnnualPayroll }: ManagerStatCardsProps) {
     return (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8 mt-4">

--- a/components/manager/stat-cards/types.ts
+++ b/components/manager/stat-cards/types.ts
@@ -1,5 +1,11 @@
+/**
+ * Manager-facing UI: types.
+ */
 import type { ReactNode } from "react";
 
+/**
+ * ManagerStatCardProps type/interface.
+ */
 export interface ManagerStatCardProps {
     title: string;
     icon?: ReactNode;
@@ -7,6 +13,9 @@ export interface ManagerStatCardProps {
     description?: string;
 }
 
+/**
+ * ManagerStatCardsProps type/interface.
+ */
 export interface ManagerStatCardsProps {
     totalEmployees?: number;
     totalAnnualPayroll?: number;

--- a/components/manager/summary-cards/SummaryCards.tsx
+++ b/components/manager/summary-cards/SummaryCards.tsx
@@ -1,3 +1,6 @@
+/**
+ * Manager-facing UI: SummaryCards.
+ */
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { BenefitSummaryCardProps } from "../types";
 import {
@@ -8,6 +11,9 @@ import {
 import { SummaryCardsProps } from "./types";
 import { formatCurrency } from "@/utils/formatCurrency";
 
+/**
+ * Renders the Benefit Summary Card UI.
+ */
 export function BenefitSummaryCard({ title, icon, count, description }: BenefitSummaryCardProps) {
     return (
         <Card>
@@ -25,6 +31,9 @@ export function BenefitSummaryCard({ title, icon, count, description }: BenefitS
     )
 }
 
+/**
+ * Default export: Summary Cards.
+ */
 export default function SummaryCards({
     companyBenefitsCount,
     optionalBenefitsCount,

--- a/components/manager/summary-cards/types.ts
+++ b/components/manager/summary-cards/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Manager-facing UI: types.
+ */
 export interface SummaryCardsProps {
     companyBenefitsCount?: number;
     optionalBenefitsCount?: number;

--- a/components/manager/types.ts
+++ b/components/manager/types.ts
@@ -1,10 +1,19 @@
+/**
+ * Manager-facing UI: types.
+ */
 import type React from "react";
 
+/**
+ * BenefitDetailsProps type/interface.
+ */
 export interface BenefitDetailsProps {
     title: string
     value: string
 }
 
+/**
+ * BenefitSummaryCardProps type/interface.
+ */
 export interface BenefitSummaryCardProps {
     title: string
     icon: React.ReactNode

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,3 +1,6 @@
+/**
+ * shadcn/ui primitive wrapper: alert.
+ */
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -19,6 +22,9 @@ const alertVariants = cva(
   }
 )
 
+/**
+ * Alert UI primitive (exported from this module).
+ */
 function Alert({
   className,
   variant,
@@ -34,6 +40,9 @@ function Alert({
   )
 }
 
+/**
+ * AlertTitle UI primitive (exported from this module).
+ */
 function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -47,6 +56,9 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+/**
+ * AlertDescription UI primitive (exported from this module).
+ */
 function AlertDescription({
   className,
   ...props

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,10 +1,16 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: avatar.
+ */
 import * as React from "react"
 import { Avatar as AvatarPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Avatar UI primitive (exported from this module).
+ */
 function Avatar({
   className,
   size = "default",
@@ -25,6 +31,9 @@ function Avatar({
   )
 }
 
+/**
+ * AvatarImage UI primitive (exported from this module).
+ */
 function AvatarImage({
   className,
   ...props
@@ -38,6 +47,9 @@ function AvatarImage({
   )
 }
 
+/**
+ * AvatarFallback UI primitive (exported from this module).
+ */
 function AvatarFallback({
   className,
   ...props
@@ -54,6 +66,9 @@ function AvatarFallback({
   )
 }
 
+/**
+ * AvatarBadge UI primitive (exported from this module).
+ */
 function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
@@ -70,6 +85,9 @@ function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
   )
 }
 
+/**
+ * AvatarGroup UI primitive (exported from this module).
+ */
 function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -83,6 +101,9 @@ function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+/**
+ * AvatarGroupCount UI primitive (exported from this module).
+ */
 function AvatarGroupCount({
   className,
   ...props

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,9 +1,15 @@
+/**
+ * shadcn/ui primitive wrapper: badge.
+ */
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Badge Variants.
+ */
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
@@ -26,6 +32,9 @@ const badgeVariants = cva(
   }
 )
 
+/**
+ * Badge UI primitive (exported from this module).
+ */
 function Badge({
   className,
   variant = "default",

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,9 +1,15 @@
+/**
+ * shadcn/ui primitive wrapper: button.
+ */
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Button Variants.
+ */
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
@@ -38,6 +44,9 @@ const buttonVariants = cva(
   }
 )
 
+/**
+ * Button UI primitive (exported from this module).
+ */
 function Button({
   className,
   variant = "default",

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: calendar.
+ */
 import * as React from "react"
 
 type CalendarClassNames = {
@@ -7,6 +10,9 @@ type CalendarClassNames = {
   nav?: string
 }
 
+/**
+ * CalendarProps type/interface.
+ */
 export type CalendarProps = {
   mode?: "single"
   selected?: Date
@@ -33,6 +39,9 @@ function parseDateFromInput(value: string) {
   return new Date(year, month - 1, day)
 }
 
+/**
+ * Renders the Calendar UI.
+ */
 export function Calendar({
   selected,
   onSelect,

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,7 +1,13 @@
+/**
+ * shadcn/ui primitive wrapper: card.
+ */
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Card UI primitive (exported from this module).
+ */
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -15,6 +21,9 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+/**
+ * CardHeader UI primitive (exported from this module).
+ */
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -28,6 +37,9 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+/**
+ * CardTitle UI primitive (exported from this module).
+ */
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -38,6 +50,9 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+/**
+ * CardDescription UI primitive (exported from this module).
+ */
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -48,6 +63,9 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+/**
+ * CardAction UI primitive (exported from this module).
+ */
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -61,6 +79,9 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+/**
+ * CardContent UI primitive (exported from this module).
+ */
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -71,6 +92,9 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+/**
+ * CardFooter UI primitive (exported from this module).
+ */
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: chart.
+ */
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
 
@@ -8,6 +11,9 @@ import { cn } from "@/lib/utils"
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const
 
+/**
+ * ChartConfig type/interface.
+ */
 export type ChartConfig = {
   [k in string]: {
     label?: React.ReactNode
@@ -34,6 +40,9 @@ function useChart() {
   return context
 }
 
+/**
+ * ChartContainer UI primitive (exported from this module).
+ */
 function ChartContainer({
   id,
   className,
@@ -69,6 +78,9 @@ function ChartContainer({
   )
 }
 
+/**
+ * ChartStyle UI primitive (exported from this module).
+ */
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
     ([, config]) => config.theme || config.color
@@ -102,8 +114,14 @@ ${colorConfig
   )
 }
 
+/**
+ * ChartTooltip UI primitive (exported from this module).
+ */
 const ChartTooltip = RechartsPrimitive.Tooltip
 
+/**
+ * ChartTooltipContent UI primitive (exported from this module).
+ */
 function ChartTooltipContent({
   active,
   payload,
@@ -250,8 +268,14 @@ function ChartTooltipContent({
   )
 }
 
+/**
+ * ChartLegend UI primitive (exported from this module).
+ */
 const ChartLegend = RechartsPrimitive.Legend
 
+/**
+ * ChartLegendContent UI primitive (exported from this module).
+ */
 function ChartLegendContent({
   className,
   hideIcon = false,

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+/**
+ * shadcn/ui primitive wrapper: data-table.
+ */
 import { useEffect, useState } from "react";
 import {
   ColumnDef,
@@ -17,6 +20,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ArrowUpDown, ChevronLeft, ChevronRight } from "lucide-react";
 
+/**
+ * Renders the Sortable Header UI.
+ */
 export function SortableHeader<T>({ column, label }: { column: Column<T, unknown>; label: string }) {
   return (
     <Button
@@ -41,6 +47,9 @@ interface DataTableProps<T> {
   onRowClick?: (row: T) => void;
 }
 
+/**
+ * Renders the Data Table UI.
+ */
 export function DataTable<T>({
   columns,
   data,

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: dialog.
+ */
 import * as React from "react"
 import { XIcon } from "lucide-react"
 import { Dialog as DialogPrimitive } from "radix-ui"
@@ -7,30 +10,45 @@ import { Dialog as DialogPrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 
+/**
+ * Dialog UI primitive (exported from this module).
+ */
 function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
+/**
+ * DialogTrigger UI primitive (exported from this module).
+ */
 function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
+/**
+ * DialogPortal UI primitive (exported from this module).
+ */
 function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
+/**
+ * DialogClose UI primitive (exported from this module).
+ */
 function DialogClose({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
+/**
+ * DialogOverlay UI primitive (exported from this module).
+ */
 function DialogOverlay({
   className,
   ...props
@@ -47,6 +65,9 @@ function DialogOverlay({
   )
 }
 
+/**
+ * DialogContent UI primitive (exported from this module).
+ */
 function DialogContent({
   className,
   children,
@@ -81,6 +102,9 @@ function DialogContent({
   )
 }
 
+/**
+ * DialogHeader UI primitive (exported from this module).
+ */
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -91,6 +115,9 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+/**
+ * DialogFooter UI primitive (exported from this module).
+ */
 function DialogFooter({
   className,
   showCloseButton = false,
@@ -118,6 +145,9 @@ function DialogFooter({
   )
 }
 
+/**
+ * DialogTitle UI primitive (exported from this module).
+ */
 function DialogTitle({
   className,
   ...props
@@ -131,6 +161,9 @@ function DialogTitle({
   )
 }
 
+/**
+ * DialogDescription UI primitive (exported from this module).
+ */
 function DialogDescription({
   className,
   ...props

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,17 +1,26 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: dropdown-menu.
+ */
 import * as React from "react"
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * DropdownMenu UI primitive (exported from this module).
+ */
 function DropdownMenu({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
 }
 
+/**
+ * DropdownMenuPortal UI primitive (exported from this module).
+ */
 function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
@@ -20,6 +29,9 @@ function DropdownMenuPortal({
   )
 }
 
+/**
+ * DropdownMenuTrigger UI primitive (exported from this module).
+ */
 function DropdownMenuTrigger({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
@@ -31,6 +43,9 @@ function DropdownMenuTrigger({
   )
 }
 
+/**
+ * DropdownMenuContent UI primitive (exported from this module).
+ */
 function DropdownMenuContent({
   className,
   sideOffset = 4,
@@ -51,6 +66,9 @@ function DropdownMenuContent({
   )
 }
 
+/**
+ * DropdownMenuGroup UI primitive (exported from this module).
+ */
 function DropdownMenuGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
@@ -59,6 +77,9 @@ function DropdownMenuGroup({
   )
 }
 
+/**
+ * DropdownMenuItem UI primitive (exported from this module).
+ */
 function DropdownMenuItem({
   className,
   inset,
@@ -82,6 +103,9 @@ function DropdownMenuItem({
   )
 }
 
+/**
+ * DropdownMenuCheckboxItem UI primitive (exported from this module).
+ */
 function DropdownMenuCheckboxItem({
   className,
   children,
@@ -108,6 +132,9 @@ function DropdownMenuCheckboxItem({
   )
 }
 
+/**
+ * DropdownMenuRadioGroup UI primitive (exported from this module).
+ */
 function DropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
@@ -119,6 +146,9 @@ function DropdownMenuRadioGroup({
   )
 }
 
+/**
+ * DropdownMenuRadioItem UI primitive (exported from this module).
+ */
 function DropdownMenuRadioItem({
   className,
   children,
@@ -143,6 +173,9 @@ function DropdownMenuRadioItem({
   )
 }
 
+/**
+ * DropdownMenuLabel UI primitive (exported from this module).
+ */
 function DropdownMenuLabel({
   className,
   inset,
@@ -163,6 +196,9 @@ function DropdownMenuLabel({
   )
 }
 
+/**
+ * DropdownMenuSeparator UI primitive (exported from this module).
+ */
 function DropdownMenuSeparator({
   className,
   ...props
@@ -176,6 +212,9 @@ function DropdownMenuSeparator({
   )
 }
 
+/**
+ * DropdownMenuShortcut UI primitive (exported from this module).
+ */
 function DropdownMenuShortcut({
   className,
   ...props
@@ -192,12 +231,18 @@ function DropdownMenuShortcut({
   )
 }
 
+/**
+ * DropdownMenuSub UI primitive (exported from this module).
+ */
 function DropdownMenuSub({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
   return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
 }
 
+/**
+ * DropdownMenuSubTrigger UI primitive (exported from this module).
+ */
 function DropdownMenuSubTrigger({
   className,
   inset,
@@ -222,6 +267,9 @@ function DropdownMenuSubTrigger({
   )
 }
 
+/**
+ * DropdownMenuSubContent UI primitive (exported from this module).
+ */
 function DropdownMenuSubContent({
   className,
   ...props

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,7 +1,13 @@
+/**
+ * shadcn/ui primitive wrapper: input.
+ */
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Input UI primitive (exported from this module).
+ */
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
     <input

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,10 +1,16 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: label.
+ */
 import * as React from "react"
 import { Label as LabelPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Label UI primitive (exported from this module).
+ */
 function Label({
   className,
   ...props

--- a/components/ui/navbars/employee-navbar.tsx
+++ b/components/ui/navbars/employee-navbar.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+/**
+ * Role/shell navbar UI: employee navbar.
+ */
 import * as React from "react"
 import { useEffect, useRef, useState } from "react"
 import { Button } from "@/components/animate-ui/components/buttons/button"
@@ -24,6 +27,9 @@ import Link from "next/link"
 import Image from "next/image"
 
 // Simple logo component for the navbar
+/**
+ * Logo UI primitive (exported from this module).
+ */
 const Logo = (props: React.SVGAttributes<SVGElement>) => {
   return (
     <svg
@@ -43,6 +49,9 @@ const Logo = (props: React.SVGAttributes<SVGElement>) => {
 }
 
 // Hamburger icon component
+/**
+ * HamburgerIcon UI primitive (exported from this module).
+ */
 const HamburgerIcon = ({ className, ...props }: React.SVGAttributes<SVGElement>) => (
   <svg
     aria-label="Menu"
@@ -74,6 +83,9 @@ const HamburgerIcon = ({ className, ...props }: React.SVGAttributes<SVGElement>)
   </svg>
 )
 
+/**
+ * EmployeeNavbarNavLink type/interface.
+ */
 export interface EmployeeNavbarNavLink {
   href: string
   icon?: React.ReactNode
@@ -81,6 +93,9 @@ export interface EmployeeNavbarNavLink {
   active?: boolean
 }
 
+/**
+ * EmployeeNavbarProps type/interface.
+ */
 export interface EmployeeNavbarProps extends React.HTMLAttributes<HTMLElement> {
   logo?: React.ReactNode
   logoHref?: string
@@ -97,6 +112,9 @@ const defaultNavigationLinks: EmployeeNavbarNavLink[] = [
   { href: "/employee/paystubs", icon: <HandCoins />, label: "Pay Stubs" },
 ]
 
+/**
+ * Renders the Employee Navbar UI.
+ */
 export const EmployeeNavbar = React.forwardRef<HTMLElement, EmployeeNavbarProps>(
   (
     {

--- a/components/ui/navbars/external-search-navbar.tsx
+++ b/components/ui/navbars/external-search-navbar.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+/**
+ * Role/shell navbar UI: external search navbar.
+ */
 import Image from "next/image"
 import Link from "next/link"
 import { useTheme } from "next-themes"
@@ -7,6 +10,9 @@ import { cn } from "@/lib/utils"
 import { ArrowLeft, Moon, Sun } from "lucide-react"
 import { Button } from "@/components/ui/button"
 
+/**
+ * Renders the External Search Navbar UI.
+ */
 export function ExternalSearchNavbar() {
   const { theme, setTheme } = useTheme()
 

--- a/components/ui/navbars/manager-navbar.tsx
+++ b/components/ui/navbars/manager-navbar.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+/**
+ * Role/shell navbar UI: manager navbar.
+ */
 import * as React from "react"
 import { useEffect, useRef, useState } from "react"
 import { Button } from "@/components/animate-ui/components/buttons/button"
@@ -25,6 +28,9 @@ import Link from "next/link"
 import Image from "next/image"
 
 // Simple logo component for the navbar
+/**
+ * Logo UI primitive (exported from this module).
+ */
 const Logo = (props: React.SVGAttributes<SVGElement>) => {
   return (
     <svg
@@ -44,6 +50,9 @@ const Logo = (props: React.SVGAttributes<SVGElement>) => {
 }
 
 // Hamburger icon component
+/**
+ * HamburgerIcon UI primitive (exported from this module).
+ */
 const HamburgerIcon = ({ className, ...props }: React.SVGAttributes<SVGElement>) => (
   <svg
     aria-label="Menu"
@@ -76,6 +85,9 @@ const HamburgerIcon = ({ className, ...props }: React.SVGAttributes<SVGElement>)
 )
 
 // Types
+/**
+ * ManagerNavbarNavLink type/interface.
+ */
 export interface ManagerNavbarNavLink {
   href: string
   icon?: React.ReactNode
@@ -83,6 +95,9 @@ export interface ManagerNavbarNavLink {
   active?: boolean
 }
 
+/**
+ * ManagerNavbarProps type/interface.
+ */
 export interface ManagerNavbarProps extends React.HTMLAttributes<HTMLElement> {
   logo?: React.ReactNode
   logoHref?: string
@@ -101,6 +116,9 @@ const defaultNavigationLinks: ManagerNavbarNavLink[] = [
   { href: "/manager/benefits", icon: <FileText />, label: "Benefits" },
 ]
 
+/**
+ * Renders the Manager Navbar UI.
+ */
 export const ManagerNavbar = React.forwardRef<HTMLElement, ManagerNavbarProps>(
   (
     {

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -1,4 +1,7 @@
 "use client"
+/**
+ * shadcn/ui primitive wrapper: navigation-menu.
+ */
 import * as React from "react"
 import { cva } from "class-variance-authority"
 import { ChevronDownIcon } from "lucide-react"
@@ -6,6 +9,9 @@ import { NavigationMenu as NavigationMenuPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * NavigationMenu UI primitive (exported from this module).
+ */
 function NavigationMenu({
   className,
   children,
@@ -30,6 +36,9 @@ function NavigationMenu({
   )
 }
 
+/**
+ * NavigationMenuList UI primitive (exported from this module).
+ */
 function NavigationMenuList({
   className,
   ...props
@@ -46,6 +55,9 @@ function NavigationMenuList({
   )
 }
 
+/**
+ * NavigationMenuItem UI primitive (exported from this module).
+ */
 function NavigationMenuItem({
   className,
   ...props
@@ -59,10 +71,16 @@ function NavigationMenuItem({
   )
 }
 
+/**
+ * Navigation Menu Trigger Style.
+ */
 const navigationMenuTriggerStyle = cva(
   "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1"
 )
 
+/**
+ * NavigationMenuTrigger UI primitive (exported from this module).
+ */
 function NavigationMenuTrigger({
   className,
   children,
@@ -83,6 +101,9 @@ function NavigationMenuTrigger({
   )
 }
 
+/**
+ * NavigationMenuContent UI primitive (exported from this module).
+ */
 function NavigationMenuContent({
   className,
   ...props
@@ -100,6 +121,9 @@ function NavigationMenuContent({
   )
 }
 
+/**
+ * NavigationMenuViewport UI primitive (exported from this module).
+ */
 function NavigationMenuViewport({
   className,
   ...props
@@ -122,6 +146,9 @@ function NavigationMenuViewport({
   )
 }
 
+/**
+ * NavigationMenuLink UI primitive (exported from this module).
+ */
 function NavigationMenuLink({
   className,
   ...props
@@ -138,6 +165,9 @@ function NavigationMenuLink({
   )
 }
 
+/**
+ * NavigationMenuIndicator UI primitive (exported from this module).
+ */
 function NavigationMenuIndicator({
   className,
   ...props

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,22 +1,34 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: popover.
+ */
 import * as React from "react"
 import { Popover as PopoverPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Popover UI primitive (exported from this module).
+ */
 function Popover({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
 }
 
+/**
+ * PopoverTrigger UI primitive (exported from this module).
+ */
 function PopoverTrigger({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
+/**
+ * PopoverContent UI primitive (exported from this module).
+ */
 function PopoverContent({
   className,
   align = "center",
@@ -39,12 +51,18 @@ function PopoverContent({
   )
 }
 
+/**
+ * PopoverAnchor UI primitive (exported from this module).
+ */
 function PopoverAnchor({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
 }
 
+/**
+ * PopoverHeader UI primitive (exported from this module).
+ */
 function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -55,6 +73,9 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+/**
+ * PopoverTitle UI primitive (exported from this module).
+ */
 function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
   return (
     <div
@@ -65,6 +86,9 @@ function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
   )
 }
 
+/**
+ * PopoverDescription UI primitive (exported from this module).
+ */
 function PopoverDescription({
   className,
   ...props

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,10 +1,16 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: progress.
+ */
 import * as React from "react"
 import { Progress as ProgressPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Progress UI primitive (exported from this module).
+ */
 function Progress({
   className,
   value,

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,29 +1,44 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: select.
+ */
 import * as React from "react"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 import { Select as SelectPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Select UI primitive (exported from this module).
+ */
 function Select({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
   return <SelectPrimitive.Root data-slot="select" {...props} />
 }
 
+/**
+ * SelectGroup UI primitive (exported from this module).
+ */
 function SelectGroup({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Group>) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />
 }
 
+/**
+ * SelectValue UI primitive (exported from this module).
+ */
 function SelectValue({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
   return <SelectPrimitive.Value data-slot="select-value" {...props} />
 }
 
+/**
+ * SelectTrigger UI primitive (exported from this module).
+ */
 function SelectTrigger({
   className,
   size = "default",
@@ -50,6 +65,9 @@ function SelectTrigger({
   )
 }
 
+/**
+ * SelectContent UI primitive (exported from this module).
+ */
 function SelectContent({
   className,
   children,
@@ -87,6 +105,9 @@ function SelectContent({
   )
 }
 
+/**
+ * SelectLabel UI primitive (exported from this module).
+ */
 function SelectLabel({
   className,
   ...props
@@ -100,6 +121,9 @@ function SelectLabel({
   )
 }
 
+/**
+ * SelectItem UI primitive (exported from this module).
+ */
 function SelectItem({
   className,
   children,
@@ -127,6 +151,9 @@ function SelectItem({
   )
 }
 
+/**
+ * SelectSeparator UI primitive (exported from this module).
+ */
 function SelectSeparator({
   className,
   ...props
@@ -140,6 +167,9 @@ function SelectSeparator({
   )
 }
 
+/**
+ * SelectScrollUpButton UI primitive (exported from this module).
+ */
 function SelectScrollUpButton({
   className,
   ...props
@@ -158,6 +188,9 @@ function SelectScrollUpButton({
   )
 }
 
+/**
+ * SelectScrollDownButton UI primitive (exported from this module).
+ */
 function SelectScrollDownButton({
   className,
   ...props

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,10 +1,16 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: separator.
+ */
 import * as React from "react"
 import { Separator as SeparatorPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Separator UI primitive (exported from this module).
+ */
 function Separator({
   className,
   orientation = "horizontal",

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,8 +1,14 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: spinner.
+ */
 import { LoaderCircleIcon, LoaderIcon, LoaderPinwheelIcon, type LucideProps } from "lucide-react"
 import { cn } from "@/lib/utils"
 
+/**
+ * SpinnerProps type/interface.
+ */
 export type SpinnerProps = LucideProps & {
   variant?:
   | "default"
@@ -266,6 +272,9 @@ const Infinite = ({ size = 24, ...props }: SpinnerVariantProps) => {
   )
 }
 
+/**
+ * Renders the Spinner UI.
+ */
 export const Spinner = ({ variant, ...props }: SpinnerProps) => {
   switch (variant) {
     case "circle":

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,10 +1,16 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: switch.
+ */
 import * as React from "react"
 import { Switch as SwitchPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Switch UI primitive (exported from this module).
+ */
 function Switch({
   className,
   size = "default",

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,9 +1,15 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: table.
+ */
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Table UI primitive (exported from this module).
+ */
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
@@ -19,6 +25,9 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   )
 }
 
+/**
+ * TableHeader UI primitive (exported from this module).
+ */
 function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   return (
     <thead
@@ -29,6 +38,9 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   )
 }
 
+/**
+ * TableBody UI primitive (exported from this module).
+ */
 function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
   return (
     <tbody
@@ -39,6 +51,9 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
   )
 }
 
+/**
+ * TableFooter UI primitive (exported from this module).
+ */
 function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
   return (
     <tfoot
@@ -52,6 +67,9 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
   )
 }
 
+/**
+ * TableRow UI primitive (exported from this module).
+ */
 function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
   return (
     <tr
@@ -65,6 +83,9 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
   )
 }
 
+/**
+ * TableHead UI primitive (exported from this module).
+ */
 function TableHead({ className, ...props }: React.ComponentProps<"th">) {
   return (
     <th
@@ -78,6 +99,9 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
   )
 }
 
+/**
+ * TableCell UI primitive (exported from this module).
+ */
 function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   return (
     <td
@@ -91,6 +115,9 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   )
 }
 
+/**
+ * TableCaption UI primitive (exported from this module).
+ */
 function TableCaption({
   className,
   ...props

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,11 +1,17 @@
 "use client"
 
+/**
+ * shadcn/ui primitive wrapper: tabs.
+ */
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Tabs as TabsPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Tabs UI primitive (exported from this module).
+ */
 function Tabs({
   className,
   orientation = "horizontal",
@@ -25,6 +31,9 @@ function Tabs({
   )
 }
 
+/**
+ * Tabs List Variants.
+ */
 const tabsListVariants = cva(
   "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
   {
@@ -40,6 +49,9 @@ const tabsListVariants = cva(
   }
 )
 
+/**
+ * TabsList UI primitive (exported from this module).
+ */
 function TabsList({
   className,
   variant = "default",
@@ -56,6 +68,9 @@ function TabsList({
   )
 }
 
+/**
+ * TabsTrigger UI primitive (exported from this module).
+ */
 function TabsTrigger({
   className,
   ...props
@@ -75,6 +90,9 @@ function TabsTrigger({
   )
 }
 
+/**
+ * TabsContent UI primitive (exported from this module).
+ */
 function TabsContent({
   className,
   ...props

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,7 +1,13 @@
+/**
+ * shadcn/ui primitive wrapper: textarea.
+ */
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * Textarea UI primitive (exported from this module).
+ */
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
     <textarea

--- a/hooks/__tests__/use-controlled-state.test.tsx
+++ b/hooks/__tests__/use-controlled-state.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for hooks.
+ */
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/hooks/use-add-benefit.ts
+++ b/hooks/use-add-benefit.ts
@@ -1,6 +1,12 @@
+/**
+ * React Query mutation hook for adding a COMPANY or OPTIONAL benefit.
+ */
 import { useState } from "react"
 import { addBenefit } from "@/lib/supabase/benefits"
 
+/**
+ * Hook: use Add Benefit.
+ */
 export function useAddBenefit(initialType: "COMPANY" | "OPTIONAL" = "COMPANY") {
     const [benefit, setBenefit] = useState("")
     const [tag, setTag] = useState("")

--- a/hooks/use-add-employee.ts
+++ b/hooks/use-add-employee.ts
@@ -1,6 +1,12 @@
+/**
+ * React Query mutation hook for adding an employee row.
+ */
 import { useState } from "react"
 import { addEmployee as addEmployeeToDB } from "@/lib/supabase/employee"
 
+/**
+ * Hook: use Add Employee.
+ */
 export function useAddEmployee() {
     const [firstName, setFirstName] = useState("")
     const [lastName, setLastName] = useState("")

--- a/hooks/use-controlled-state.tsx
+++ b/hooks/use-controlled-state.tsx
@@ -1,3 +1,6 @@
+/**
+ * Controlled/uncontrolled state helper (prop value + onChange vs internal state).
+ */
 import * as React from 'react';
 
 interface CommonControlledStateProps<T> {
@@ -7,6 +10,9 @@ interface CommonControlledStateProps<T> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+/**
+ * Hook: use Controlled State.
+ */
 export function useControlledState<T, Rest extends any[] = []>(
   props: CommonControlledStateProps<T> & {
     onChange?: (value: T, ...args: Rest) => void;

--- a/hooks/use-is-in-view.tsx
+++ b/hooks/use-is-in-view.tsx
@@ -1,3 +1,6 @@
+/**
+ * IntersectionObserver-backed in-view hook for animate-ui effects.
+ */
 import * as React from 'react';
 import { useInView, type UseInViewOptions } from 'motion/react';
 
@@ -7,6 +10,13 @@ interface UseIsInViewOptions {
   inViewMargin?: UseInViewOptions['margin'];
 }
 
+/**
+ * Tracks whether `ref`'s element is in view (motion/react useInView).
+ * When `options.inView` is falsy, always reports isInView=true (opt-out).
+ * @param ref - Imperative handle target for the observed element.
+ * @param options - inView gate, once, and margin forwarded to useInView.
+ * @returns Local ref to attach and current isInView flag.
+ */
 function useIsInView<T extends HTMLElement = HTMLElement>(
   ref: React.Ref<T>,
   options: UseIsInViewOptions = {},

--- a/lib/__tests__/payroll-actions.test.ts
+++ b/lib/__tests__/payroll-actions.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for lib.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock next/headers (required by server client)

--- a/lib/__tests__/payroll.test.ts
+++ b/lib/__tests__/payroll.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for lib.
+ */
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('@/utils/supabase/client', () => ({

--- a/lib/__tests__/supabase/benefits.test.ts
+++ b/lib/__tests__/supabase/benefits.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for lib//supabase.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@/utils/supabase/client', () => ({

--- a/lib/__tests__/supabase/employee.test.ts
+++ b/lib/__tests__/supabase/employee.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for lib//supabase.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@/utils/supabase/client', () => ({

--- a/lib/__tests__/supabase/paystubs.test.ts
+++ b/lib/__tests__/supabase/paystubs.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for lib//supabase.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@/utils/supabase/client', () => ({

--- a/lib/__tests__/supabase/time-entries.test.ts
+++ b/lib/__tests__/supabase/time-entries.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest coverage for lib//supabase.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { mockGetCurrentEmployee } = vi.hoisted(() => ({

--- a/lib/benefits/eligibility.ts
+++ b/lib/benefits/eligibility.ts
@@ -1,3 +1,7 @@
+/**
+ * Optional-benefits eligibility rules: state hour thresholds (ACA/HI), employment-status
+ * exemptions, and loading/error lockout. Pure functions — no I/O.
+ */
 export interface EligibilityInput {
   employmentStatus: string | null;
   hoursPerWeek: number | null;
@@ -6,6 +10,9 @@ export interface EligibilityInput {
   error?: boolean;
 }
 
+/**
+ * EligibilityResult type/interface.
+ */
 export interface EligibilityResult {
   eligible: boolean;
   loading?: boolean;
@@ -43,6 +50,12 @@ const STATE_RULES: Record<string, StateRule> = {
 
 const EXEMPT_EMPLOYMENT_STATUSES = new Set(["CONTRACTOR", "SEASONAL", "INTERN", "1099"]);
 
+/**
+ * Evaluates optional-benefits eligibility for an employee snapshot.
+ * error=true locks enrollment; loading/null hours keep eligible=false with loading.
+ * @param employee - Status, hours/week, and state used for thresholds.
+ * @returns EligibilityResult with thresholdHours and optional reason/shortMessage.
+ */
 export function checkOptionalBenefitsEligibility(employee: EligibilityInput): EligibilityResult {
   const rule = (employee.state && STATE_RULES[employee.state.toUpperCase()]) || DEFAULT_STATE_RULE;
   const { thresholdHours, marketplaceMessage } = rule;
@@ -95,6 +108,9 @@ export function checkOptionalBenefitsEligibility(employee: EligibilityInput): El
   };
 }
 
+/**
+ * True when checkOptionalBenefitsEligibility(...).eligible — used by runPayroll.
+ */
 export function shouldApplyOptionalDeductions(employee: EligibilityInput): boolean {
   return checkOptionalBenefitsEligibility(employee).eligible;
 }

--- a/lib/get-strict-context.tsx
+++ b/lib/get-strict-context.tsx
@@ -1,5 +1,11 @@
+/**
+ * Factory for a typed React context that throws if used outside its provider.
+ */
 import * as React from 'react';
 
+/**
+ * Get Strict Context.
+ */
 function getStrictContext<T>(
   name?: string,
 ): readonly [

--- a/lib/supabase/benefits.ts
+++ b/lib/supabase/benefits.ts
@@ -1,11 +1,24 @@
+/**
+ * Browser-client benefit catalog CRUD and employee_benefits enrollment upserts.
+ * SECURITY: enrollment ties to the authenticated employee via getCurrentEmployee.
+ */
 import { createClient } from "@/utils/supabase/client";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { getCurrentEmployee } from "./employee";
 import { TablesInsert, TablesUpdate } from "../interfaces/database.types";
 
+/**
+ * BenefitInsert type/interface.
+ */
 export type BenefitInsert = TablesInsert<"benefits">;
+/**
+ * BenefitUpdate type/interface.
+ */
 export type BenefitUpdate = TablesUpdate<"benefits">;
 
+/**
+ * Inserts a benefits catalog row (COMPANY or OPTIONAL).
+ */
 export const addBenefit = async (company_benefit: BenefitInsert) => {
     const supabase = createClient();
     const { error } = await supabase
@@ -18,6 +31,9 @@ export const addBenefit = async (company_benefit: BenefitInsert) => {
     }
 }
 
+/**
+ * Lists benefits where type=COMPANY.
+ */
 export const getCompanyBenefits = async () => {
     const supabase = createClient();
 
@@ -34,6 +50,9 @@ export const getCompanyBenefits = async () => {
     return company_benefits
 }
 
+/**
+ * Lists benefits where type=OPTIONAL.
+ */
 export const getOptionalBenefits = async () => {
     const supabase = createClient();
 
@@ -50,6 +69,10 @@ export const getOptionalBenefits = async () => {
     return optional_benefits
 }
 
+/**
+ * ACTIVE employee_benefits joined to OPTIONAL benefit rows for one employee.
+ * @param supabaseClient - Optional server client (payroll path); else browser client.
+ */
 export const getActiveOptionalEmployeeBenefits = async (employee_id: string, supabaseClient?: SupabaseClient) => {
     const supabase = supabaseClient || createClient();
 
@@ -72,6 +95,10 @@ export const getActiveOptionalEmployeeBenefits = async (employee_id: string, sup
     return optionalBenefits;
 }
 
+/**
+ * Upserts enrollment for the current employee on (employee_id, benefit_id).
+ * SECURITY: derives employee_id from the auth session.
+ */
 export const upsertEmployeeBenefit = async ({
     benefit_id,
     status
@@ -100,6 +127,9 @@ export const upsertEmployeeBenefit = async ({
     return data;
 };
 
+/**
+ * Deletes a benefits catalog row by id.
+ */
 export const deleteBenefit = async (id: string) => {
     const supabase = createClient();
     const { error } = await supabase
@@ -113,6 +143,9 @@ export const deleteBenefit = async (id: string) => {
     }
 }
 
+/**
+ * Updates a benefits catalog row by id.
+ */
 export const updateBenefit = async (id: string, updates: BenefitUpdate) => {
     const supabase = createClient();
     const { error } = await supabase
@@ -126,6 +159,9 @@ export const updateBenefit = async (id: string, updates: BenefitUpdate) => {
     }
 }
 
+/**
+ * Exact count of COMPANY benefits.
+ */
 export const getCompanyBenefitsCount = async () => {
     const supabase = createClient();
 
@@ -142,6 +178,9 @@ export const getCompanyBenefitsCount = async () => {
     return count || 0;
 };
 
+/**
+ * Exact count of OPTIONAL benefits.
+ */
 export const getOptionalBenefitsCount = async () => {
     const supabase = createClient();
 

--- a/lib/supabase/employee.tsx
+++ b/lib/supabase/employee.tsx
@@ -1,3 +1,7 @@
+/**
+ * Browser-client employee CRUD, directory, dashboard aggregates, and current-user lookup.
+ * SECURITY: returns full employee rows (address, pay_rate, tax rates) — do not log or expose to unauthorized roles.
+ */
 import { createClient } from "@/utils/supabase/client";
 import { Tables, TablesInsert } from "../interfaces/database.types";
 import { DirectoryEntry } from "@/lib/supabase/types";
@@ -6,14 +10,31 @@ const supabase = createClient();
 type EmployeeInsert = TablesInsert<"employees">;
 
 // Role-based employee types for different access levels
+/**
+ * ManagerEmployee type/interface.
+ */
 export type ManagerEmployee = Tables<"employees">;
 
+/**
+ * EmployeeSearch type/interface.
+ */
 export type EmployeeSearch = Omit<Tables<"employees">, 'address_line' | 'zip_code' | 'city' | 'state' | 'pay_rate' | 'pay_frequency'>;
 
+/**
+ * VisitorSearch type/interface.
+ */
 export type VisitorSearch = Pick<Tables<"employees">, 'id' | 'first_name' | 'last_name' | 'position' | 'phone' | 'email'>;
 
+/**
+ * EmployeeWithProfile type/interface.
+ */
 export type EmployeeWithProfile = ManagerEmployee | EmployeeSearch | VisitorSearch;
 
+/**
+ * Inserts an employees row.
+ * SECURITY: accepts full PII + pay fields.
+ * @throws On Supabase error.
+ */
 export const addEmployee = async (employee: EmployeeInsert) => {
     const { error } = await supabase
         .from("employees")
@@ -25,6 +46,10 @@ export const addEmployee = async (employee: EmployeeInsert) => {
     }
 }
 
+/**
+ * Selects all employees.
+ * SECURITY: full rows — manager-only surfaces.
+ */
 export const getEmployees = async () => {
     const { data: employees, error } = await supabase
         .from("employees")
@@ -38,6 +63,9 @@ export const getEmployees = async () => {
     return employees;
 }
 
+/**
+ * Exact count of ACTIVE employees (head-only query).
+ */
 export const getActiveEmployeesCount = async () => {
     const { count, error } = await supabase
         .from("employees")
@@ -52,6 +80,10 @@ export const getActiveEmployeesCount = async () => {
     return count ?? 0;
 }
 
+/**
+ * Sums estimated annual pay for ACTIVE employees (salary / biweekly×26 / hourly×40×52).
+ * SECURITY: aggregates compensation.
+ */
 export const getTotalAnnualPayroll = async () => {
     const { data: employees, error } = await supabase
         .from("employees")
@@ -85,6 +117,10 @@ export const getTotalAnnualPayroll = async () => {
     return totalAnnual;
 }
 
+/**
+ * Partial update of an employee by id.
+ * SECURITY: may change pay/PII fields.
+ */
 export const updateEmployee = async (id: string, updates: Partial<EmployeeInsert>) => {
     const { error } = await supabase
         .from("employees")
@@ -97,6 +133,9 @@ export const updateEmployee = async (id: string, updates: Partial<EmployeeInsert
     }
 }
 
+/**
+ * Deletes an employee by id.
+ */
 export const deleteEmployee = async (id: string) => {
     const { error } = await supabase
         .from("employees")
@@ -109,6 +148,11 @@ export const deleteEmployee = async (id: string) => {
     }
 }
 
+/**
+ * Resolves auth user → profiles → employees for the signed-in session.
+ * SECURITY: returns user, profile, and full employee row.
+ * @throws If unauthenticated or profile/employee missing.
+ */
 export async function getCurrentEmployee() {
     const {
         data: { user },
@@ -146,6 +190,9 @@ export async function getCurrentEmployee() {
     }
 }
 
+/**
+ * Maps employees + departments into DirectoryEntry rows (no pay fields).
+ */
 export const getEmployeeDirectory = async (): Promise<DirectoryEntry[]> => {
     const { data: employees, error: employeesError } = await supabase
         .from("employees")
@@ -184,6 +231,9 @@ export const getEmployeeDirectory = async (): Promise<DirectoryEntry[]> => {
     });
 }
 
+/**
+ * Counts employees grouped by department name.
+ */
 export const getEmployeeByDepartment = async () => {
     const { data, error } = await supabase
         .from("employees")
@@ -203,6 +253,10 @@ export const getEmployeeByDepartment = async () => {
     return grouped;
 }
 
+/**
+ * Aggregates annualized pay by position for charts.
+ * SECURITY: compensation aggregates.
+ */
 export const getEmployeeSalaryByPosition = async () => {
     const { data, error } = await supabase
         .from("employees")

--- a/lib/supabase/payroll-actions.ts
+++ b/lib/supabase/payroll-actions.ts
@@ -1,5 +1,11 @@
 'use server'
 
+/**
+ * Server actions that orchestrate a payroll run: insert run, load ACTIVE employees +
+ * APPROVED time entries, compute per-employee records (with eligibility-gated optional
+ * benefit deductions), then mark the run COMPLETED.
+ * SECURITY: requires an authenticated user; mutates payroll_runs/payroll_records with PII-adjacent pay data.
+ */
 import { createClient } from "@/utils/supabase/server";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { TablesInsert, Tables } from "@/lib/interfaces/database.types";
@@ -12,9 +18,11 @@ type EmployeeBenefitRow = Tables<"employee_benefits"> & {
     benefit?: Pick<Tables<"benefits">, "id" | "type" | "monthly_cost"> | null;
 };
 
-// Buckets entries into Mon→Sun UTC weeks, returning a Map of week-start ISO
-// date → total approved hours that week. Shared by the per-week eligibility
-// calculation in runPayroll so payroll matches the UI's per-week gate.
+/**
+ * Buckets entries into Mon→Sun UTC weeks → total approved hours that week.
+ * Shared by the per-week eligibility calculation in runPayroll so payroll
+ * matches the UI's per-week gate.
+ */
 const weeklyApprovedHours = (entries: Tables<"time_entries">[]): Map<string, number> => {
     const weekTotals = new Map<string, number>();
     for (const entry of entries) {
@@ -25,6 +33,11 @@ const weeklyApprovedHours = (entries: Tables<"time_entries">[]): Map<string, num
     return weekTotals;
 };
 
+/**
+ * Inserts a PROCESSING payroll_run for the given period.
+ * @param user - Auth user id stored as run_by.
+ * @throws On insert failure.
+ */
 export const insertPayrollRun = async (supabase: SupabaseClient, payPeriodStart: string, payPeriodEnd: string, user: string) => {
     const { data: run, error: runError } = await supabase
         .from("payroll_runs")
@@ -46,6 +59,10 @@ export const insertPayrollRun = async (supabase: SupabaseClient, payPeriodStart:
     return run;
 }
 
+/**
+ * Loads all employees with employment_status ACTIVE.
+ * SECURITY: full employee rows including pay/tax fields.
+ */
 export const getActiveEmployees = async (supabase: SupabaseClient) => {
     const { data: employees, error: eError } = await supabase
         .from("employees")
@@ -60,6 +77,9 @@ export const getActiveEmployees = async (supabase: SupabaseClient) => {
     return employees;
 }
 
+/**
+ * APPROVED time_entries with work_date in [start, end] inclusive.
+ */
 export const getTimeEntriesForPayPeriod = async (supabase: SupabaseClient, payPeriodStart: string, payPeriodEnd: string) => {
     const { data: time_entries, error: tError } = await supabase
         .from("time_entries")
@@ -76,6 +96,9 @@ export const getTimeEntriesForPayPeriod = async (supabase: SupabaseClient, payPe
     return time_entries;
 }
 
+/**
+ * Bulk-inserts computed payroll_records (nulls filtered out).
+ */
 export const insertPayrollRecords = async (supabase: SupabaseClient, records: TablesInsert<"payroll_records">[]) => {
     const { error: rError } = await supabase
         .from("payroll_records")
@@ -87,6 +110,10 @@ export const insertPayrollRecords = async (supabase: SupabaseClient, records: Ta
     }
 };
 
+/**
+ * Aggregates record totals onto the run and sets status COMPLETED.
+ * @returns Fixed-string totals for gross, net, and taxes.
+ */
 export const updatePayrollRun = async (supabase: SupabaseClient, records: TablesInsert<"payroll_records">[], payroll_run: Tables<"payroll_runs">, user: string) => {
     const valid_records = records.filter((r): r is NonNullable<typeof r> => !!r);
     const total_gross_pay = valid_records.reduce((total, curr) => total + curr.gross_pay, 0);
@@ -121,6 +148,16 @@ export const updatePayrollRun = async (supabase: SupabaseClient, records: Tables
     };
 };
 
+/**
+ * End-to-end payroll orchestration for one pay period.
+ * Rejects unauthenticated callers, invalid dates, and duplicate PROCESSING/COMPLETED runs.
+ * Applies optional benefit deductions only when shouldApplyOptionalDeductions passes
+ * for that employee's weekly approved hours.
+ * SECURITY: mutates payroll tables; requires auth session.
+ * @param payPeriodStart - Inclusive YYYY-MM-DD.
+ * @param payPeriodEnd - Inclusive YYYY-MM-DD.
+ * @throws If unauthenticated, dates invalid, or period already run.
+ */
 export const runPayroll = async (payPeriodStart: string, payPeriodEnd: string) => {
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();

--- a/lib/supabase/payroll.tsx
+++ b/lib/supabase/payroll.tsx
@@ -1,10 +1,20 @@
+/**
+ * Pure payroll math + browser-client fetches for payroll runs/records.
+ * Uses a fixed 26 bi-weekly periods/year; overtime is computed per Mon–Sun UTC week.
+ * SECURITY: handles pay rates, tax rates, and net pay — do not log employee compensation.
+ */
 import { createClient } from "@/utils/supabase/client";
 import { Tables } from "@/lib/interfaces/database.types";
 
 const supabase = createClient();
 const BI_WEEKLY_PAY_PERIODS = 26;
+/** Rounds to cents using EPSILON to reduce binary float noise. */
 const roundMoney = (value: number) => Math.round((value + Number.EPSILON) * 100) / 100;
 
+/**
+ * Fetches all payroll_runs rows.
+ * @throws Relays Supabase errors after console.error.
+ */
 export const getPayrollRuns = async () => {
     const { data: payroll_runs, error } = await supabase
         .from("payroll_runs")
@@ -18,6 +28,11 @@ export const getPayrollRuns = async () => {
     return payroll_runs;
 };
 
+/**
+ * Fetches payroll_records with joined employee name + pay_frequency.
+ * SECURITY: includes compensation fields — manager-facing.
+ * @throws Relays Supabase errors.
+ */
 export const getPayrollRecords = async () => {
     const { data: payroll_records, error } = await supabase
         .from("payroll_records")
@@ -68,6 +83,17 @@ function computeWeeklyOvertime(
 }
 
 // Now accepts benefitDeduction (number) and subtracts it from net_pay
+/**
+ * Computes one employee's payroll_record fields for a run.
+ * HOURLY/BI_WEEKLY: per-week OT at 1.5× after 40h; SALARY: pay_rate/26.
+ * Monthly benefitDeduction is prorated by 12/26 only when gross_pay > 0.
+ * SECURITY: input/output contain pay and tax amounts — do not log.
+ * @param employee - Employee row with pay_rate, frequency, and tax rates.
+ * @param time_entries - Period entries (filtered to this employee inside).
+ * @param payroll_run - Parent run (id stamped onto the result).
+ * @param benefitDeduction - Monthly optional/company deduction total (default 0).
+ * @returns Insert-shaped record fields (hours, taxes, net_pay).
+ */
 export const calculatePayRollForEmployee = (
     employee: Tables<"employees">,
     time_entries: Tables<"time_entries">[],
@@ -120,6 +146,10 @@ export const calculatePayRollForEmployee = (
     };
 };
 
+/**
+ * Average benefit_deductions across the latest 6 payroll_records (by period start).
+ * @returns 0 when no records exist.
+ */
 export const getAverageBenefitDeductions = async () => {
     const supabase = createClient()
     const LATEST_PAY_PERIODS = 6

--- a/lib/supabase/paystubs.ts
+++ b/lib/supabase/paystubs.ts
@@ -1,6 +1,15 @@
+/**
+ * Fetches the authenticated employee's payroll_records joined with run + employee fields
+ * for paystub rendering.
+ * SECURITY: returns compensation and address PII for the current employee only.
+ */
 import { createClient } from "@/utils/supabase/client";
 import { getCurrentEmployee } from "./employee";
 
+/**
+ * Payroll records for the current employee with nested run + employee fields.
+ * SECURITY: compensation and address PII for the authenticated employee.
+ */
 export async function getEmployeePaystubs() {
 	const supabase = createClient();
 	const { employee } = await getCurrentEmployee();

--- a/lib/supabase/time-entries.ts
+++ b/lib/supabase/time-entries.ts
@@ -1,3 +1,7 @@
+/**
+ * Time-entry create/list helpers and approved-hours lookback for benefits eligibility.
+ * SECURITY: scopes all queries to the authenticated employee.
+ */
 import { createClient } from "@/utils/supabase/client"
 import { getCurrentEmployee } from "./employee"
 import { getWeekStartKey, getWeekStartUTC } from "@/lib/utils/date-helpers"
@@ -7,6 +11,12 @@ import { getWeekStartKey, getWeekStartUTC } from "@/lib/utils/date-helpers"
 const ELIGIBILITY_LOOKBACK_WEEKS = 4
 
 
+/**
+ * Inserts a PENDING time entry for the current employee.
+ * @param workDate - YYYY-MM-DD.
+ * @param hoursWorked - Non-negative finite hours.
+ * @throws On validation or Supabase failure.
+ */
 export const createTimeEntry = async (workDate: string, hoursWorked: number) => {
   const supabase = createClient()
 
@@ -40,6 +50,9 @@ export const createTimeEntry = async (workDate: string, hoursWorked: number) => 
   return data
 }
 
+/**
+ * Latest 5 time entries for the current employee (newest work_date first).
+ */
 export const getRecentTimeEntries = async () => {
   const supabase = createClient()
   const { employee } = await getCurrentEmployee()
@@ -58,6 +71,10 @@ export const getRecentTimeEntries = async () => {
   return data ?? []
 }
 
+/**
+ * Max approved hours in any single Mon–Sun UTC week over the last 4 weeks
+ * (including the current week). Used as hoursPerWeek for eligibility.
+ */
 export const getApprovedHoursWorked = async (referenceDate?: Date): Promise<number> => {
   const supabase = createClient()
   const { employee } = await getCurrentEmployee()

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Shared directory-entry shape used by employee directory mapping.
+ */
 export type DirectoryEntry = {
     id: string;
     first_name: string | null;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,14 +1,26 @@
+/**
+ * General UI helpers: Tailwind class merge (cn), day/period formatting.
+ */
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+/**
+ * Merges class names with clsx + tailwind-merge.
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * Short weekday label for a Date (en-US).
+ */
 export function getShortDay(date: Date) {
   return new Intl.DateTimeFormat("en-US", { weekday: "short" }).format(date)
 }
 
+/**
+ * Formats start/end date-only strings as "Mon D–Mon D, YYYY" (noon-anchored).
+ */
 export function formatPayPeriod(start?: string | null, end?: string | null) {
   if (!start || !end) return "Unknown period"
 
@@ -29,6 +41,9 @@ export function formatPayPeriod(start?: string | null, end?: string | null) {
   return `${startText}–${endText}`
 }
 
+/**
+ * Formats a paid-on date string; noon-anchors date-only values to avoid TZ shifts.
+ */
 export function formatPaidOn(date?: string | null) {
   if (!date) return "Unknown"
 

--- a/lib/utils/date-helpers.ts
+++ b/lib/utils/date-helpers.ts
@@ -1,7 +1,14 @@
-// Normalizes the supplied date to midnight UTC and shifts it back to the Monday
-// of that ISO-week. Accepts either a Date or a YYYY-MM-DD / ISO string. Used by
-// the payroll weekly aggregation and the per-week eligibility window so both
-// agree on the workweek boundary.
+/**
+ * UTC week-start helpers shared by payroll overtime and eligibility lookbacks.
+ */
+
+/**
+ * Normalizes a date to midnight UTC and shifts it to the Monday of that ISO week.
+ * Accepts a Date or YYYY-MM-DD / ISO string so payroll weekly aggregation and the
+ * per-week eligibility window agree on the workweek boundary.
+ * @param date - Instant or date-only/ISO string (defaults to now).
+ * @returns Monday 00:00:00.000Z for that week.
+ */
 export function getWeekStartUTC(date: Date | string = new Date()): Date {
   const d = typeof date === "string" ? new Date(date) : date;
   const monday = new Date(Date.UTC(
@@ -13,6 +20,11 @@ export function getWeekStartUTC(date: Date | string = new Date()): Date {
   return monday;
 }
 
+/**
+ * ISO date key (YYYY-MM-DD) of the Monday that starts the UTC week for `date`.
+ * @param date - Instant or date-only/ISO string (defaults to now).
+ * @returns Week-start key used as Map keys in overtime/eligibility bucketing.
+ */
 export function getWeekStartKey(date: Date | string = new Date()): string {
   return getWeekStartUTC(date).toISOString().slice(0, 10);
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,6 @@
+/**
+ * Next.js config for the PayCore App Router project.
+ */
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {

--- a/utils/formatCurrency.ts
+++ b/utils/formatCurrency.ts
@@ -1,3 +1,6 @@
+/**
+ * USD currency formatter for payroll/UI display.
+ */
 export function formatCurrency(value: number): string {
     return new Intl.NumberFormat("en-US", {
         style: "currency",

--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser Supabase client factory (createBrowserClient).
+ * Reads NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+ * throws at module load if either is missing.
+ * SECURITY: publishable key only — never put service-role secrets in NEXT_PUBLIC_*.
+ */
 import { createBrowserClient } from "@supabase/ssr";
 import { Database } from "@/lib/interfaces/database.types";
 
@@ -8,6 +14,10 @@ if (!supabaseKey || !supabaseUrl) {
     throw new Error("Missing Supabase environment variables");
 }
 
+/**
+ * Returns a typed browser Supabase client.
+ * SECURITY: uses the publishable anon key only.
+ */
 export const createClient = () =>
     createBrowserClient<Database>(
         supabaseUrl,

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,3 +1,7 @@
+/**
+ * Cookie-backed server Supabase client for Server Components / server actions.
+ * SECURITY: session cookies drive auth — do not log cookie values.
+ */
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { Database } from "@/lib/interfaces/database.types";
@@ -5,6 +9,11 @@ import { Database } from "@/lib/interfaces/database.types";
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
 
+/**
+ * Builds a server Supabase client bound to the request cookie store.
+ * SECURITY: session cookies — never log cookie values.
+ * @throws If Supabase env vars are missing.
+ */
 export async function createClient() {
 
     if (!supabaseKey || !supabaseUrl) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest config (jsdom, path aliases, setup file).
+ */
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,4 @@
+/**
+ * Vitest setup: Testing Library jest-dom matchers and shared mocks.
+ */
 import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- Apply ENGINEERING-PRINCIPLES §10 file headers + export/public JSDoc across ~125 TS/TSX sources (docs-only).
- Flag `SECURITY:` on payroll, auth, and PII surfaces (pay calc, employee CRUD, paystubs/PDF, Supabase clients, login/search).
- Link bare TODOs to issues: `#186` (navbar role), `#187` (EmployeeTable tests), `#188` (CompanyBenefits tests), `#189` (OptionalBenefits tests).

## Test plan
- [x] `npm run test:run` — 206 passed, 39 skipped
- [x] `npm run build` — success (with placeholder Supabase env)
- [x] `npx tsc --noEmit` — pre-existing test-file errors only (same on `main`; Next build tsc clean)
- [ ] CI Build + Lint Code Base green
- [ ] CodeRabbit review addressed or replied


Made with [Cursor](https://cursor.com)