### PR TITLE
docs: gap-fill §10 @example and export JSDoc

### DIFF
--- a/app/employee/benefits/page.tsx
+++ b/app/employee/benefits/page.tsx
@@ -22,7 +22,10 @@ import { checkOptionalBenefitsEligibility } from "@/lib/benefits/eligibility"
 import type { EmployeeBenefit, BenefitOption } from "@/app/employee/benefits/types"
 
 /**
- * Default export: Benefits Page.
+ * Benefits Page App Router page.
+ * @returns The rendered BenefitsPage UI.
+ * @example
+ * // Routed page component (BenefitsPage)
  */
 export default function BenefitsPage() {
   const [employeeId, setEmployeeId] = useState<string>("");

--- a/app/employee/benefits/page.tsx
+++ b/app/employee/benefits/page.tsx
@@ -22,7 +22,7 @@ import { checkOptionalBenefitsEligibility } from "@/lib/benefits/eligibility"
 import type { EmployeeBenefit, BenefitOption } from "@/app/employee/benefits/types"
 
 /**
- * Benefits Page App Router page.
+ * Employee benefits enrollment App Router page.
  * @returns The rendered BenefitsPage UI.
  * @example
  * // Routed page component (BenefitsPage)

--- a/app/employee/dashboard/page.tsx
+++ b/app/employee/dashboard/page.tsx
@@ -34,7 +34,7 @@ const initialTimesheets = [
 const weeklyTarget = 40
 
 /**
- * Employee Dashboard Page App Router page.
+ * Employee dashboard App Router page.
  * @returns The rendered EmployeeDashboardPage UI.
  * @example
  * // Routed page component (EmployeeDashboardPage)

--- a/app/employee/dashboard/page.tsx
+++ b/app/employee/dashboard/page.tsx
@@ -34,7 +34,10 @@ const initialTimesheets = [
 const weeklyTarget = 40
 
 /**
- * Default export: Employee Dashboard Page.
+ * Employee Dashboard Page App Router page.
+ * @returns The rendered EmployeeDashboardPage UI.
+ * @example
+ * // Routed page component (EmployeeDashboardPage)
  */
 export default function EmployeeDashboardPage() {
 

--- a/app/employee/paystubs/page.tsx
+++ b/app/employee/paystubs/page.tsx
@@ -288,7 +288,10 @@ function PayStubCard({
 }
 
 /**
- * Default export: Pay Stubs Page.
+ * Pay Stubs Page App Router page.
+ * @returns The rendered PayStubsPage UI.
+ * @example
+ * // Routed page component (PayStubsPage)
  */
 export default function PayStubsPage() {
   const [paystubs, setPaystubs] = useState<ProcessedPaystub[]>([]);

--- a/app/employee/paystubs/page.tsx
+++ b/app/employee/paystubs/page.tsx
@@ -288,7 +288,7 @@ function PayStubCard({
 }
 
 /**
- * Pay Stubs Page App Router page.
+ * Employee paystubs list/PDF App Router page.
  * @returns The rendered PayStubsPage UI.
  * @example
  * // Routed page component (PayStubsPage)

--- a/app/employee/paystubs/utils.ts
+++ b/app/employee/paystubs/utils.ts
@@ -17,6 +17,12 @@ export const COMPANY_INFO = {
  * Deterministic pseudo-random in [min, min+range) from a string seed.
  * Used for synthetic YTD/SSN display values on demo paystubs (not real SSN).
  * SECURITY: output can look like an SSN — never treat as a real identifier.
+ * @param seed - Hash seed (usually record id).
+ * @param min - Inclusive lower bound.
+ * @param range - Width of the half-open interval.
+ * @returns Integer in [min, min+range).
+ * @example
+ * stableNumber("rec-1", 1000, 9000) // => deterministic 4-digit-ish int
  */
 function stableNumber(seed: string, min: number, range: number): number {
   let hash = 0;
@@ -29,6 +35,11 @@ function stableNumber(seed: string, min: number, range: number): number {
 /**
  * Normalizes a RawPaystubRow into ProcessedPaystub for PDF/list UI.
  * SECURITY: carries pay and address fields through to the PDF.
+ * @param row - Payroll record with nested run + employee joins.
+ * @returns Display/PDF-ready paystub including synthetic YTD/SSN demo fields.
+ * @example
+ * const stub = processPaystubData(rawRow);
+ * // stub.netPay / stub.ssn ready for CheckPDF
  */
 export function processPaystubData(row: RawPaystubRow): ProcessedPaystub {
   const payrollRun = row.payroll_runs;

--- a/app/internal-search/actions.ts
+++ b/app/internal-search/actions.ts
@@ -40,6 +40,10 @@ async function resolveAuthenticatedRole(
 /**
  * Server-side name search returning role-appropriate employee fields.
  * SECURITY: pay/address only for elevated roles.
+ * @param name - Substring matched against first/last name.
+ * @returns Matching rows plus the caller's resolved role string.
+ * @example
+ * const { results, role } = await searchEmployeesByNameAction("hernandez");
  */
 export async function searchEmployeesByNameAction(
     name: string,
@@ -79,6 +83,9 @@ export async function searchEmployeesByNameAction(
 
 /**
  * Returns the signed-in profiles.role string (or empty when unauthenticated).
+ * @returns Role string from profiles, or "" when no session/profile.
+ * @example
+ * const role = await getAuthenticatedUserRoleAction(); // e.g. "MANAGER"
  */
 export async function getAuthenticatedUserRoleAction(): Promise<string> {
     const supabase = await createClient();

--- a/app/internal-search/employee-result-card.tsx
+++ b/app/internal-search/employee-result-card.tsx
@@ -35,7 +35,11 @@ function Field({ label, value }: FieldProps) {
 }
 
 /**
- * Renders the Employee Result Card UI.
+ * Directory result card; field visibility follows role-gated payload shape.
+ * @param employee - Search hit (visitor-safe or elevated columns).
+ * @returns Card showing name, role, and optional pay/address.
+ * @example
+ * <EmployeeResultCard employee={hit} />
  */
 export function EmployeeResultCard({ employee }: Props) {
     const fullName = `${employee.first_name ?? ""} ${employee.last_name ?? ""}`.trim() || "Unknown";

--- a/app/internal-search/page.tsx
+++ b/app/internal-search/page.tsx
@@ -37,7 +37,10 @@ function createSearchState(sessionKey: string): SearchState {
 }
 
 /**
- * Default export: External Employee Search Page.
+ * Public/internal directory search page with role-aware result cards.
+ * @returns Search UI for looking up coworkers by name.
+ * @example
+ * // Routed at /internal-search
  */
 export default function ExternalEmployeeSearchPage() {
   const { role, userId } = useAuthenticatedRole();

--- a/app/internal-search/use-authenticated-role.ts
+++ b/app/internal-search/use-authenticated-role.ts
@@ -13,7 +13,10 @@ type AuthenticatedRoleState = {
 };
 
 /**
- * Hook: use Authenticated Role.
+ * Client hook that loads the signed-in profiles.role via server action.
+ * @returns `{ role, loading, error }` for directory UI gating.
+ * @example
+ * const { role, loading } = useAuthenticatedRole();
  */
 export function useAuthenticatedRole(): AuthenticatedRoleState {
     const [authState, setAuthState] = useState<AuthenticatedRoleState>({

--- a/app/internal-search/utils.ts
+++ b/app/internal-search/utils.ts
@@ -4,7 +4,12 @@
 import type { EmployeeWithProfile } from "@/lib/supabase/employee";
 
 /**
- * Format Location.
+ * Joins address fields for directory cards; falls back when none present.
+ * @param employee - Directory row (visitor-safe or elevated columns).
+ * @returns Comma-joined location, or "Location not available".
+ * @example
+ * formatLocation({ city: "Austin", state: "TX" } as EmployeeWithProfile)
+ * // => "Austin, TX"
  */
 export function formatLocation(employee: EmployeeWithProfile) {
     const pieces = [
@@ -18,7 +23,11 @@ export function formatLocation(employee: EmployeeWithProfile) {
 }
 
 /**
- * Has Pay Info.
+ * Type guard: employee payload includes pay_rate (elevated roles).
+ * @param employee - Directory search result row.
+ * @returns Whether pay_rate is present on the object.
+ * @example
+ * if (hasPayInfo(row)) console.log(row.pay_rate);
  */
 export function hasPayInfo(
     employee: EmployeeWithProfile,
@@ -27,7 +36,11 @@ export function hasPayInfo(
 }
 
 /**
- * Has Address Info.
+ * Type guard: employee payload includes address_line.
+ * @param employee - Directory search result row.
+ * @returns Whether address_line is present on the object.
+ * @example
+ * if (hasAddressInfo(row)) console.log(row.address_line);
  */
 export function hasAddressInfo(
     employee: EmployeeWithProfile,
@@ -36,7 +49,11 @@ export function hasAddressInfo(
 }
 
 /**
- * Has Pay Frequency.
+ * Type guard: employee payload includes pay_frequency.
+ * @param employee - Directory search result row.
+ * @returns Whether pay_frequency is present on the object.
+ * @example
+ * if (hasPayFrequency(row)) console.log(row.pay_frequency);
  */
 export function hasPayFrequency(
     employee: EmployeeWithProfile,
@@ -45,7 +62,12 @@ export function hasPayFrequency(
 }
 
 /**
- * Capitalize Role.
+ * Title-cases a profiles.role string for display; defaults to Visitor.
+ * @param role - Raw role from auth/profile (any casing), or null.
+ * @returns Capitalized role label.
+ * @example
+ * capitalizeRole("MANAGER") // => "Manager"
+ * capitalizeRole(null) // => "Visitor"
  */
 export function capitalizeRole(role: string | null): string {
     const normalized = role?.toLowerCase() ?? 'visitor';
@@ -53,7 +75,12 @@ export function capitalizeRole(role: string | null): string {
 }
 
 /**
- * Get Initials.
+ * Two-letter initials for avatar fallbacks.
+ * @param firstName - Given name (may be null/blank).
+ * @param lastName - Family name (may be null/blank).
+ * @returns Uppercase initials, or "?" when both missing.
+ * @example
+ * getInitials("Ada", "Lovelace") // => "AL"
  */
 export function getInitials(firstName: string | null, lastName: string | null): string {
     const first = firstName?.trim().charAt(0) ?? '';

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,11 @@ export const metadata: Metadata = {
 };
 
 /**
- * Default export: Root Layout.
+ * Root Layout component.
+ * @param children - Nested React nodes.
+ * @returns The rendered RootLayout UI.
+ * @example
+ * // <RootLayout children={...} />
  */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
 

--- a/app/manager/benefits/page.tsx
+++ b/app/manager/benefits/page.tsx
@@ -8,7 +8,7 @@ import { getCompanyBenefitsCount, getOptionalBenefitsCount } from "@/lib/supabas
 import { getAverageBenefitDeductions } from "@/lib/supabase/payroll"
 
 /**
- * dynamic App Router page.
+ * Manager benefits catalog App Router page.
  * @returns The rendered dynamic UI.
  * @example
  * // Routed page component (dynamic)

--- a/app/manager/benefits/page.tsx
+++ b/app/manager/benefits/page.tsx
@@ -7,10 +7,19 @@ import OptionalBenefitsGrid from "@/components/manager/optional-benefits/Optiona
 import { getCompanyBenefitsCount, getOptionalBenefitsCount } from "@/lib/supabase/benefits"
 import { getAverageBenefitDeductions } from "@/lib/supabase/payroll"
 
+/**
+ * dynamic App Router page.
+ * @returns The rendered dynamic UI.
+ * @example
+ * // Routed page component (dynamic)
+ */
 export const dynamic = "force-dynamic"
 
 /**
- * Default export: Benefits Page.
+ * Benefits Page App Router page.
+ * @returns The rendered BenefitsPage UI.
+ * @example
+ * // Routed page component (BenefitsPage)
  */
 export default async function BenefitsPage() {
     const results = await Promise.allSettled([

--- a/app/manager/benefits/page.tsx
+++ b/app/manager/benefits/page.tsx
@@ -7,16 +7,10 @@ import OptionalBenefitsGrid from "@/components/manager/optional-benefits/Optiona
 import { getCompanyBenefitsCount, getOptionalBenefitsCount } from "@/lib/supabase/benefits"
 import { getAverageBenefitDeductions } from "@/lib/supabase/payroll"
 
-/**
- * Manager benefits catalog App Router page.
- * @returns The rendered dynamic UI.
- * @example
- * // Routed page component (dynamic)
- */
 export const dynamic = "force-dynamic"
 
 /**
- * Benefits Page App Router page.
+ * Manager benefits catalog App Router page.
  * @returns The rendered BenefitsPage UI.
  * @example
  * // Routed page component (BenefitsPage)

--- a/app/manager/dashboard/page.tsx
+++ b/app/manager/dashboard/page.tsx
@@ -5,16 +5,10 @@ import ManagerStatCards from "@/components/manager/stat-cards/Statcards"
 import GridContent from "@/components/manager/grid-content/GridContent"
 import { getActiveEmployeesCount, getTotalAnnualPayroll } from "@/lib/supabase/employee"
 
-/**
- * Manager dashboard App Router page.
- * @returns The rendered dynamic UI.
- * @example
- * // Routed page component (dynamic)
- */
 export const dynamic = "force-dynamic"
 
 /**
- * Manager Dashboard Page App Router page.
+ * Manager dashboard App Router page.
  * @returns The rendered ManagerDashboardPage UI.
  * @example
  * // Routed page component (ManagerDashboardPage)

--- a/app/manager/dashboard/page.tsx
+++ b/app/manager/dashboard/page.tsx
@@ -5,10 +5,19 @@ import ManagerStatCards from "@/components/manager/stat-cards/Statcards"
 import GridContent from "@/components/manager/grid-content/GridContent"
 import { getActiveEmployeesCount, getTotalAnnualPayroll } from "@/lib/supabase/employee"
 
+/**
+ * dynamic App Router page.
+ * @returns The rendered dynamic UI.
+ * @example
+ * // Routed page component (dynamic)
+ */
 export const dynamic = "force-dynamic"
 
 /**
- * Default export: Manager Dashboard Page.
+ * Manager Dashboard Page App Router page.
+ * @returns The rendered ManagerDashboardPage UI.
+ * @example
+ * // Routed page component (ManagerDashboardPage)
  */
 export default async function ManagerDashboardPage() {
     const results = await Promise.allSettled([

--- a/app/manager/dashboard/page.tsx
+++ b/app/manager/dashboard/page.tsx
@@ -6,7 +6,7 @@ import GridContent from "@/components/manager/grid-content/GridContent"
 import { getActiveEmployeesCount, getTotalAnnualPayroll } from "@/lib/supabase/employee"
 
 /**
- * dynamic App Router page.
+ * Manager dashboard App Router page.
  * @returns The rendered dynamic UI.
  * @example
  * // Routed page component (dynamic)

--- a/app/manager/employee-table/page.tsx
+++ b/app/manager/employee-table/page.tsx
@@ -178,7 +178,10 @@ function ActionsCell({ employee, onUpdate, onDelete, onError }: {
 }
 
 /**
- * Default export: Employee Table.
+ * Employee Table App Router page.
+ * @returns The rendered EmployeeTable UI.
+ * @example
+ * // Routed page component (EmployeeTable)
  */
 export default function EmployeeTable() {
   const {

--- a/app/manager/employee-table/page.tsx
+++ b/app/manager/employee-table/page.tsx
@@ -178,7 +178,7 @@ function ActionsCell({ employee, onUpdate, onDelete, onError }: {
 }
 
 /**
- * Employee Table App Router page.
+ * Employee Table presentational component.
  * @returns The rendered EmployeeTable UI.
  * @example
  * // Routed page component (EmployeeTable)

--- a/app/manager/payroll-records-table/page.tsx
+++ b/app/manager/payroll-records-table/page.tsx
@@ -31,7 +31,10 @@ function formatHours(value: number | null): string {
 }
 
 /**
- * Default export: Payroll Table.
+ * Payroll Table App Router page.
+ * @returns The rendered PayrollTable UI.
+ * @example
+ * // Routed page component (PayrollTable)
  */
 export default function PayrollTable() {
   const [startDate, setStartDate] = useState("");

--- a/app/manager/payroll-records-table/page.tsx
+++ b/app/manager/payroll-records-table/page.tsx
@@ -31,7 +31,7 @@ function formatHours(value: number | null): string {
 }
 
 /**
- * Payroll Table App Router page.
+ * Payroll Table presentational component.
  * @returns The rendered PayrollTable UI.
  * @example
  * // Routed page component (PayrollTable)

--- a/app/manager/payroll-status/page.tsx
+++ b/app/manager/payroll-status/page.tsx
@@ -23,11 +23,11 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useState, useRef } from "react";
 
 /**
- * Payroll Section App Router page.
- * @param title - See component props.
- * @param value - See component props.
- * @param icon - See component props.
- * @param color - See component props.
+ * Payroll Section presentational component.
+ * @param title - Section/card title text.
+ * @param value - Primary metric or display value.
+ * @param icon - Icon element or icon component.
+ * @param color - Text color class for the value.
  * @returns The rendered PayrollSection UI.
  * @example
  * <PayrollSection title={...}, value={...}, icon={...}, color={...} />
@@ -45,10 +45,10 @@ export function PayrollSection({ title, value, icon, color }: PayrollSectionProp
 }
 
 /**
- * Status Card App Router page.
- * @param text - See component props.
- * @param icon - See component props.
- * @param color - See component props.
+ * Status Card presentational component.
+ * @param text - Title/description copy for the status state.
+ * @param icon - Icon element or icon component.
+ * @param color - Border/background color classes for the card.
  * @param children - Nested React nodes.
  * @returns The rendered StatusCard UI.
  * @example
@@ -208,7 +208,7 @@ function PayrollStatusContent() {
 }
 
 /**
- * Payroll Status Page App Router page.
+ * Manager payroll-run status App Router page.
  * @returns The rendered PayrollStatusPage UI.
  * @example
  * // Routed page component (PayrollStatusPage)

--- a/app/manager/payroll-status/page.tsx
+++ b/app/manager/payroll-status/page.tsx
@@ -23,7 +23,14 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useState, useRef } from "react";
 
 /**
- * Renders the Payroll Section UI.
+ * Payroll Section App Router page.
+ * @param title - See component props.
+ * @param value - See component props.
+ * @param icon - See component props.
+ * @param color - See component props.
+ * @returns The rendered PayrollSection UI.
+ * @example
+ * <PayrollSection title={...}, value={...}, icon={...}, color={...} />
  */
 export function PayrollSection({ title, value, icon, color }: PayrollSectionProps) {
     return (
@@ -38,7 +45,14 @@ export function PayrollSection({ title, value, icon, color }: PayrollSectionProp
 }
 
 /**
- * Renders the Status Card UI.
+ * Status Card App Router page.
+ * @param text - See component props.
+ * @param icon - See component props.
+ * @param color - See component props.
+ * @param children - Nested React nodes.
+ * @returns The rendered StatusCard UI.
+ * @example
+ * <StatusCard text={...}, icon={...}, color={...}, children={...} />
  */
 export function StatusCard({ text, icon, color, children }: StatusCardProps) {
     return (
@@ -194,7 +208,10 @@ function PayrollStatusContent() {
 }
 
 /**
- * Default export: Payroll Status Page.
+ * Payroll Status Page App Router page.
+ * @returns The rendered PayrollStatusPage UI.
+ * @example
+ * // Routed page component (PayrollStatusPage)
  */
 export default function PayrollStatusPage() {
     return (

--- a/app/navbar-wrapper.tsx
+++ b/app/navbar-wrapper.tsx
@@ -8,7 +8,10 @@ import { ManagerNavbar } from "@/components/ui/navbars/manager-navbar";
 import { EmployeeNavbar } from "@/components/ui/navbars/employee-navbar";
 
 /**
- * Renders ManagerNavbar or EmployeeNavbar from pathname, or null on / and /internal-search.
+ * Chooses Manager vs Employee navbar from the URL path.
+ * @returns The rendered NavbarWrapper UI.
+ * @example
+ * <NavbarWrapper />
  */
 export function NavbarWrapper() {
     const pathname = usePathname();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,10 @@ import { createClient } from "@/utils/supabase/client";
 import SplitText from "@/components/SplitText";
 
 /**
- * Default export: Login Page.
+ * Email/password login; routes by profiles.role after sign-in.
+ * @returns The rendered LoginPage UI.
+ * @example
+ * // Routed page component (LoginPage)
  */
 export default function LoginPage() {
   const supabase = createClient();

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -7,7 +7,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode, useState } from "react";
 
 /**
- * Default export: Providers.
+ * App-wide React Query (QueryClient) provider.
+ * @param children - Nested React nodes.
+ * @returns The rendered Providers UI.
+ * @example
+ * // <Providers children={...} />
  */
 export default function Providers({ children }: { children: ReactNode }) {
     const [queryClient] = useState(() => new QueryClient());

--- a/app/theme-provider.tsx
+++ b/app/theme-provider.tsx
@@ -7,7 +7,11 @@ import * as React from "react"
 import { ThemeProvider as NextThemesProvider } from "next-themes"
 
 /**
- * Renders the Theme Provider UI.
+ * Theme Provider component.
+ * @param children - Nested React nodes.
+ * @returns The rendered ThemeProvider UI.
+ * @example
+ * <ThemeProvider children={...} />
  */
 export function ThemeProvider({
     children,

--- a/components/employee/check-form/CheckPDF.tsx
+++ b/components/employee/check-form/CheckPDF.tsx
@@ -156,6 +156,10 @@ function formatDate(dateStr: string): string {
 /**
  * Renders a multi-page paystub PDF from CheckData.
  * SECURITY: document includes net pay, address, and synthetic SSN/YTD — do not log `data`.
+ * @param data - Data payload driving this view.
+ * @returns The rendered CheckPDF UI.
+ * @example
+ * <CheckPDF data={...} />
  */
 export function CheckPDF({ data }: { data: CheckData }) {
 	const ytdMultiplier = data.grossPay > 0 ? data.ytdGross / data.grossPay : 1;

--- a/components/employee/company-benefits-cards/CompanyBenefits.tsx
+++ b/components/employee/company-benefits-cards/CompanyBenefits.tsx
@@ -10,7 +10,10 @@ import { BENEFIT_ICONS } from "../constants"
 import { getCompanyBenefits } from "@/lib/supabase/benefits"
 
 /**
- * Default export: Company Benefits Card.
+ * Company Benefits Card presentational component.
+ * @returns The rendered CompanyBenefitsCard UI.
+ * @example
+ * <CompanyBenefitsCard />
  */
 export default function CompanyBenefitsCard() {
     const [company_benefits, setCompanyBenefits] = useState<Awaited<ReturnType<typeof getCompanyBenefits>>>([]);

--- a/components/employee/grid-content/GridContent.tsx
+++ b/components/employee/grid-content/GridContent.tsx
@@ -8,7 +8,15 @@ import type { GridContentProps } from "./grid-cards/types"
 import QuickStatsCard from "./grid-cards/quick-stats-card"
 
 /**
- * Default export: Grid Content.
+ * Grid Content presentational component.
+ * @param timesheets - See component props.
+ * @param setTimesheets - See component props.
+ * @param hoursByDay - See component props.
+ * @param setHoursByDay - See component props.
+ * @param chartConfig - See component props.
+ * @returns The rendered GridContent UI.
+ * @example
+ * // <GridContent timesheets={...}, setTimesheets={...}, hoursByDay={...}, setHoursByDay={...} />
  */
 export default function GridContent({ timesheets, setTimesheets, hoursByDay, setHoursByDay, chartConfig }: GridContentProps) {
     return (

--- a/components/employee/grid-content/GridContent.tsx
+++ b/components/employee/grid-content/GridContent.tsx
@@ -9,11 +9,11 @@ import QuickStatsCard from "./grid-cards/quick-stats-card"
 
 /**
  * Grid Content presentational component.
- * @param timesheets - See component props.
- * @param setTimesheets - See component props.
- * @param hoursByDay - See component props.
- * @param setHoursByDay - See component props.
- * @param chartConfig - See component props.
+ * @param timesheets - Collection rendered by this component.
+ * @param setTimesheets - Collection rendered by this component.
+ * @param hoursByDay - Component input controlling render behavior.
+ * @param setHoursByDay - Component input controlling render behavior.
+ * @param chartConfig - Component input controlling render behavior.
  * @returns The rendered GridContent UI.
  * @example
  * // <GridContent timesheets={...}, setTimesheets={...}, hoursByDay={...}, setHoursByDay={...} />

--- a/components/employee/grid-content/grid-cards/quick-stats-card.tsx
+++ b/components/employee/grid-content/grid-cards/quick-stats-card.tsx
@@ -5,7 +5,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Briefcase, Calendar, Heart, Building2 } from "lucide-react"
 
 /**
- * Default export: Quick Stats Card.
+ * Quick Stats Card presentational component.
+ * @returns The rendered QuickStatsCard UI.
+ * @example
+ * <QuickStatsCard />
  */
 export default function QuickStatsCard() {
     return (

--- a/components/employee/grid-content/grid-cards/recent-timesheets-card.tsx
+++ b/components/employee/grid-content/grid-cards/recent-timesheets-card.tsx
@@ -15,7 +15,13 @@ import { getShortDay } from "@/lib/utils"
 import type { RecentTimesheetsCardProps } from "./types"
 
 /**
- * Default export: Recent Timesheets Card.
+ * Recent Timesheets Card presentational component.
+ * @param timeEntries - See component props.
+ * @param setTimesheets - See component props.
+ * @param setHoursByDay - See component props.
+ * @returns The rendered RecentTimesheetsCard UI.
+ * @example
+ * // <RecentTimesheetsCard timeEntries={...}, setTimesheets={...}, setHoursByDay={...} />
  */
 export default function RecentTimesheetsCard({ timeEntries, setTimesheets, setHoursByDay }: RecentTimesheetsCardProps) {
     const recentEntries = [...(timeEntries || [])]

--- a/components/employee/grid-content/grid-cards/recent-timesheets-card.tsx
+++ b/components/employee/grid-content/grid-cards/recent-timesheets-card.tsx
@@ -16,9 +16,9 @@ import type { RecentTimesheetsCardProps } from "./types"
 
 /**
  * Recent Timesheets Card presentational component.
- * @param timeEntries - See component props.
- * @param setTimesheets - See component props.
- * @param setHoursByDay - See component props.
+ * @param timeEntries - Collection rendered by this component.
+ * @param setTimesheets - Collection rendered by this component.
+ * @param setHoursByDay - Component input controlling render behavior.
  * @returns The rendered RecentTimesheetsCard UI.
  * @example
  * // <RecentTimesheetsCard timeEntries={...}, setTimesheets={...}, setHoursByDay={...} />

--- a/components/employee/grid-content/grid-cards/weekly-hours-card.tsx
+++ b/components/employee/grid-content/grid-cards/weekly-hours-card.tsx
@@ -8,7 +8,12 @@ import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts"
 import type { HoursByDay } from "./types";
 
 /**
- * Default export: Weekly Hours Card Breakdown.
+ * Weekly Hours Card Breakdown presentational component.
+ * @param chartConfig - See component props.
+ * @param hoursByDay - See component props.
+ * @returns The rendered WeeklyHoursCardBreakdown UI.
+ * @example
+ * // <WeeklyHoursCardBreakdown chartConfig={...}, hoursByDay={...} />
  */
 export default function WeeklyHoursCardBreakdown({ chartConfig, hoursByDay }: { chartConfig?: ChartConfig; hoursByDay?: HoursByDay[] }) {
     if (!chartConfig || !hoursByDay) {

--- a/components/employee/grid-content/grid-cards/weekly-hours-card.tsx
+++ b/components/employee/grid-content/grid-cards/weekly-hours-card.tsx
@@ -9,8 +9,8 @@ import type { HoursByDay } from "./types";
 
 /**
  * Weekly Hours Card Breakdown presentational component.
- * @param chartConfig - See component props.
- * @param hoursByDay - See component props.
+ * @param chartConfig - Component input controlling render behavior.
+ * @param hoursByDay - Component input controlling render behavior.
  * @returns The rendered WeeklyHoursCardBreakdown UI.
  * @example
  * // <WeeklyHoursCardBreakdown chartConfig={...}, hoursByDay={...} />

--- a/components/employee/grid-content/grid-cards/ytd-earnings-card.tsx
+++ b/components/employee/grid-content/grid-cards/ytd-earnings-card.tsx
@@ -14,7 +14,10 @@ const AVG_PER_CHECK = NET_YTD / COMPLETED_PERIODS
 const progressPct = Math.round((COMPLETED_PERIODS / TOTAL_PAY_PERIODS) * 100)
 
 /**
- * Default export: YTDEarnings Card.
+ * YTDEarnings Card presentational component.
+ * @returns The rendered YTDEarningsCard UI.
+ * @example
+ * <YTDEarningsCard />
  */
 export default function YTDEarningsCard() {
     return (

--- a/components/employee/important-info-card/ImportantInfoCard.tsx
+++ b/components/employee/important-info-card/ImportantInfoCard.tsx
@@ -5,7 +5,10 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Info } from "lucide-react"
 
 /**
- * Default export: Important Info Card.
+ * Important Info Card presentational component.
+ * @returns The rendered ImportantInfoCard UI.
+ * @example
+ * <ImportantInfoCard />
  */
 export default function ImportantInfoCard() {
     return (

--- a/components/employee/optional-benefits-cards/OptionalBenefits.tsx
+++ b/components/employee/optional-benefits-cards/OptionalBenefits.tsx
@@ -14,7 +14,13 @@ import type { OptionalBenefitsCardProps } from "../types"
 import { getOptionalBenefits, upsertEmployeeBenefit } from "@/lib/supabase/benefits"
 
 /**
- * Default export: Optional Benefits Card.
+ * Optional Benefits Card presentational component.
+ * @param selected_benefits - See component props.
+ * @param set_selected_benefits - See component props.
+ * @param eligibility - See component props.
+ * @returns The rendered OptionalBenefitsCard UI.
+ * @example
+ * // <OptionalBenefitsCard selected_benefits={...}, set_selected_benefits={...}, eligibility={...} />
  */
 export default function OptionalBenefitsCard({ selected_benefits, set_selected_benefits, eligibility }: OptionalBenefitsCardProps) {
     const ineligible = eligibility !== undefined && !eligibility.eligible && !eligibility.loading

--- a/components/employee/optional-benefits-cards/OptionalBenefits.tsx
+++ b/components/employee/optional-benefits-cards/OptionalBenefits.tsx
@@ -15,9 +15,9 @@ import { getOptionalBenefits, upsertEmployeeBenefit } from "@/lib/supabase/benef
 
 /**
  * Optional Benefits Card presentational component.
- * @param selected_benefits - See component props.
- * @param set_selected_benefits - See component props.
- * @param eligibility - See component props.
+ * @param selected_benefits - Collection rendered by this component.
+ * @param set_selected_benefits - Collection rendered by this component.
+ * @param eligibility - Component input controlling render behavior.
  * @returns The rendered OptionalBenefitsCard UI.
  * @example
  * // <OptionalBenefitsCard selected_benefits={...}, set_selected_benefits={...}, eligibility={...} />

--- a/components/employee/progress-bar/ProgressBar.tsx
+++ b/components/employee/progress-bar/ProgressBar.tsx
@@ -7,10 +7,10 @@ import type { ProgressBarCardProps } from "./types"
 
 /**
  * Progress Bar Card presentational component.
- * @param company_count - See component props.
- * @param optional_count - See component props.
- * @param selected_count - See component props.
- * @param pct_company - See component props.
+ * @param company_count - Component input controlling render behavior.
+ * @param optional_count - Component input controlling render behavior.
+ * @param selected_count - Component input controlling render behavior.
+ * @param pct_company - Component input controlling render behavior.
  * @returns The rendered ProgressBarCard UI.
  * @example
  * // <ProgressBarCard company_count={...}, optional_count={...}, selected_count={...}, pct_company={...} />

--- a/components/employee/progress-bar/ProgressBar.tsx
+++ b/components/employee/progress-bar/ProgressBar.tsx
@@ -6,7 +6,14 @@ import { Progress } from "@/components/ui/progress"
 import type { ProgressBarCardProps } from "./types"
 
 /**
- * Default export: Progress Bar Card.
+ * Progress Bar Card presentational component.
+ * @param company_count - See component props.
+ * @param optional_count - See component props.
+ * @param selected_count - See component props.
+ * @param pct_company - See component props.
+ * @returns The rendered ProgressBarCard UI.
+ * @example
+ * // <ProgressBarCard company_count={...}, optional_count={...}, selected_count={...}, pct_company={...} />
  */
 export default function ProgressBarCard({ company_count, optional_count, selected_count, pct_company }: ProgressBarCardProps) {
     const clampedPct = Math.max(0, Math.min(100, pct_company));

--- a/components/employee/stat_cards/StatCards.tsx
+++ b/components/employee/stat_cards/StatCards.tsx
@@ -10,7 +10,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { EmployeeStatCardProps, HoursByDayProps } from "./types"
 
 /**
- * Renders the Employee Stat Card UI.
+ * Employee Stat Card presentational component.
+ * @param title - See component props.
+ * @param icon - See component props.
+ * @param value - See component props.
+ * @param description - See component props.
+ * @returns The rendered EmployeeStatCard UI.
+ * @example
+ * <EmployeeStatCard title={...}, icon={...}, value={...}, description={...} />
  */
 export function EmployeeStatCard({ title, icon, value, description }: EmployeeStatCardProps) {
     return (
@@ -28,7 +35,12 @@ export function EmployeeStatCard({ title, icon, value, description }: EmployeeSt
 }
 
 /**
- * Default export: Employee Stat Cards.
+ * Employee Stat Cards presentational component.
+ * @param hoursThisWeek - See component props.
+ * @param weeklyTarget - See component props.
+ * @returns The rendered EmployeeStatCards UI.
+ * @example
+ * // <EmployeeStatCards hoursThisWeek={...}, weeklyTarget={...} />
  */
 export default function EmployeeStatCards({ hoursThisWeek, weeklyTarget }: HoursByDayProps) {
     return (

--- a/components/employee/stat_cards/StatCards.tsx
+++ b/components/employee/stat_cards/StatCards.tsx
@@ -11,10 +11,10 @@ import { EmployeeStatCardProps, HoursByDayProps } from "./types"
 
 /**
  * Employee Stat Card presentational component.
- * @param title - See component props.
- * @param icon - See component props.
- * @param value - See component props.
- * @param description - See component props.
+ * @param title - Section/card title text.
+ * @param icon - Icon element or icon component.
+ * @param value - Primary metric or display value.
+ * @param description - Supporting description text.
  * @returns The rendered EmployeeStatCard UI.
  * @example
  * <EmployeeStatCard title={...}, icon={...}, value={...}, description={...} />
@@ -36,8 +36,8 @@ export function EmployeeStatCard({ title, icon, value, description }: EmployeeSt
 
 /**
  * Employee Stat Cards presentational component.
- * @param hoursThisWeek - See component props.
- * @param weeklyTarget - See component props.
+ * @param hoursThisWeek - Component input controlling render behavior.
+ * @param weeklyTarget - Component input controlling render behavior.
  * @returns The rendered EmployeeStatCards UI.
  * @example
  * // <EmployeeStatCards hoursThisWeek={...}, weeklyTarget={...} />

--- a/components/employee/summary-cards/SummaryCards.tsx
+++ b/components/employee/summary-cards/SummaryCards.tsx
@@ -8,10 +8,10 @@ import { DollarSign } from "lucide-react"
 
 /**
  * Summary Card presentational component.
- * @param title - See component props.
- * @param value - See component props.
- * @param color - See component props.
- * @param description - See component props.
+ * @param title - Section/card title text.
+ * @param value - Primary metric or display value.
+ * @param color - Accent/theme color token or class.
+ * @param description - Supporting description text.
  * @returns The rendered SummaryCard UI.
  * @example
  * <SummaryCard title={...}, value={...}, color={...}, description={...} />
@@ -28,9 +28,9 @@ export function SummaryCard({ title, value, color, description }: SummaryCardPro
 
 /**
  * Summary Cards presentational component.
- * @param company_count - See component props.
- * @param optional_count - See component props.
- * @param monthly_deduction - See component props.
+ * @param company_count - Component input controlling render behavior.
+ * @param optional_count - Component input controlling render behavior.
+ * @param monthly_deduction - Component input controlling render behavior.
  * @returns The rendered SummaryCards UI.
  * @example
  * // <SummaryCards company_count={...}, optional_count={...}, monthly_deduction={...} />

--- a/components/employee/summary-cards/SummaryCards.tsx
+++ b/components/employee/summary-cards/SummaryCards.tsx
@@ -7,7 +7,14 @@ import { DollarSign } from "lucide-react"
 
 
 /**
- * Renders the Summary Card UI.
+ * Summary Card presentational component.
+ * @param title - See component props.
+ * @param value - See component props.
+ * @param color - See component props.
+ * @param description - See component props.
+ * @returns The rendered SummaryCard UI.
+ * @example
+ * <SummaryCard title={...}, value={...}, color={...}, description={...} />
  */
 export function SummaryCard({ title, value, color, description }: SummaryCardProps) {
     return (
@@ -20,7 +27,13 @@ export function SummaryCard({ title, value, color, description }: SummaryCardPro
 }
 
 /**
- * Default export: Summary Cards.
+ * Summary Cards presentational component.
+ * @param company_count - See component props.
+ * @param optional_count - See component props.
+ * @param monthly_deduction - See component props.
+ * @returns The rendered SummaryCards UI.
+ * @example
+ * // <SummaryCards company_count={...}, optional_count={...}, monthly_deduction={...} />
  */
 export default function SummaryCards({ company_count, optional_count, monthly_deduction }: SummaryCardsProps) {
     return (

--- a/components/manager/company-benefits/CompanyBenefits.tsx
+++ b/components/manager/company-benefits/CompanyBenefits.tsx
@@ -28,8 +28,8 @@ import { useAddBenefit } from "@/hooks/use-add-benefit";
 
 /**
  * Company Benefit Details component.
- * @param title - See component props.
- * @param value - See component props.
+ * @param title - Section/card title text.
+ * @param value - Primary metric or display value.
  * @returns The rendered CompanyBenefitDetails UI.
  * @example
  * <CompanyBenefitDetails title={...}, value={...} />

--- a/components/manager/company-benefits/CompanyBenefits.tsx
+++ b/components/manager/company-benefits/CompanyBenefits.tsx
@@ -27,7 +27,12 @@ import {
 import { useAddBenefit } from "@/hooks/use-add-benefit";
 
 /**
- * Renders the Company Benefit Details UI.
+ * Company Benefit Details component.
+ * @param title - See component props.
+ * @param value - See component props.
+ * @returns The rendered CompanyBenefitDetails UI.
+ * @example
+ * <CompanyBenefitDetails title={...}, value={...} />
  */
 export function CompanyBenefitDetails({ title, value }: BenefitDetailsProps) {
     return (
@@ -39,7 +44,10 @@ export function CompanyBenefitDetails({ title, value }: BenefitDetailsProps) {
 }
 
 /**
- * Default export: Company Benefits Grid.
+ * Company Benefits Grid presentational component.
+ * @returns The rendered CompanyBenefitsGrid UI.
+ * @example
+ * <CompanyBenefitsGrid />
  */
 export default function CompanyBenefitsGrid() {
     const router = useRouter();

--- a/components/manager/grid-content/GridContent.tsx
+++ b/components/manager/grid-content/GridContent.tsx
@@ -9,7 +9,10 @@ import SalaryDistributionBarChart from "./grid-cards/salary-distribution-chart"
 import UpcomingTasksCard from "./grid-cards/upcoming-tasks"
 
 /**
- * Default export: Grid Content.
+ * Grid Content presentational component.
+ * @returns The rendered GridContent UI.
+ * @example
+ * <GridContent />
  */
 export default function GridContent() {
     return (

--- a/components/manager/grid-content/grid-cards/payroll-chart.tsx
+++ b/components/manager/grid-content/grid-cards/payroll-chart.tsx
@@ -17,6 +17,12 @@ import {
     type ChartConfig,
 } from "@/components/ui/chart"
 
+/**
+ * description component.
+ * @returns The rendered description UI.
+ * @example
+ * <description />
+ */
 export const description = "A line chart"
 
 const chartData = [
@@ -35,7 +41,10 @@ const chartConfig = {
 } satisfies ChartConfig
 
 /**
- * Default export: Payroll Trend Chart.
+ * Payroll Trend Chart presentational component.
+ * @returns The rendered PayrollTrendChart UI.
+ * @example
+ * <PayrollTrendChart />
  */
 export default function PayrollTrendChart() {
     return (

--- a/components/manager/grid-content/grid-cards/quick-actions-card.tsx
+++ b/components/manager/grid-content/grid-cards/quick-actions-card.tsx
@@ -17,7 +17,10 @@ import { useAddEmployee } from "@/hooks/use-add-employee"
 import { useState } from "react"
 
 /**
- * Default export: Quick Action Card.
+ * Quick Action Card presentational component.
+ * @returns The rendered QuickActionCard UI.
+ * @example
+ * <QuickActionCard />
  */
 export default function QuickActionCard() {
 

--- a/components/manager/grid-content/grid-cards/recent-activity.tsx
+++ b/components/manager/grid-content/grid-cards/recent-activity.tsx
@@ -13,7 +13,10 @@ const payrollRecords = ([
 ]);
 
 /**
- * Default export: Recent Activity Card.
+ * Recent Activity Card presentational component.
+ * @returns The rendered RecentActivityCard UI.
+ * @example
+ * <RecentActivityCard />
  */
 export default function RecentActivityCard() {
     return (

--- a/components/manager/grid-content/grid-cards/salary-distribution-chart.tsx
+++ b/components/manager/grid-content/grid-cards/salary-distribution-chart.tsx
@@ -28,7 +28,10 @@ const chartConfig = {
 } satisfies ChartConfig
 
 /**
- * Default export: Salary Distribution Bar Chart.
+ * Salary Distribution Bar Chart presentational component.
+ * @returns The rendered SalaryDistributionBarChart UI.
+ * @example
+ * <SalaryDistributionBarChart />
  */
 export default function SalaryDistributionBarChart() {
 

--- a/components/manager/grid-content/grid-cards/team-distribution.tsx
+++ b/components/manager/grid-content/grid-cards/team-distribution.tsx
@@ -21,7 +21,10 @@ import { useEffect, useState } from "react"
 import { ChartData, chartConfig, DEPARTMENT_COLORS } from "./types"
 
 /**
- * Default export: Team Distribution Pie Chart.
+ * Team Distribution Pie Chart presentational component.
+ * @returns The rendered TeamDistributionPieChart UI.
+ * @example
+ * <TeamDistributionPieChart />
  */
 export default function TeamDistributionPieChart() {
 

--- a/components/manager/grid-content/grid-cards/upcoming-tasks.tsx
+++ b/components/manager/grid-content/grid-cards/upcoming-tasks.tsx
@@ -6,7 +6,14 @@ import { Calendar, FileCheck, Heart } from "lucide-react"
 import { TaskCardProps } from "./types"
 
 /**
- * Renders the Task Card UI.
+ * Task Card presentational component.
+ * @param title - See component props.
+ * @param description - See component props.
+ * @param icon - See component props.
+ * @param color - See component props.
+ * @returns The rendered TaskCard UI.
+ * @example
+ * <TaskCard title={...}, description={...}, icon={...}, color={...} />
  */
 export function TaskCard({ title, description, icon, color }: TaskCardProps) {
     return (
@@ -21,7 +28,10 @@ export function TaskCard({ title, description, icon, color }: TaskCardProps) {
 }
 
 /**
- * Default export: Upcoming Tasks Card.
+ * Upcoming Tasks Card presentational component.
+ * @returns The rendered UpcomingTasksCard UI.
+ * @example
+ * <UpcomingTasksCard />
  */
 export default function UpcomingTasksCard() {
     return (

--- a/components/manager/grid-content/grid-cards/upcoming-tasks.tsx
+++ b/components/manager/grid-content/grid-cards/upcoming-tasks.tsx
@@ -7,10 +7,10 @@ import { TaskCardProps } from "./types"
 
 /**
  * Task Card presentational component.
- * @param title - See component props.
- * @param description - See component props.
- * @param icon - See component props.
- * @param color - See component props.
+ * @param title - Section/card title text.
+ * @param description - Supporting description text.
+ * @param icon - Icon element or icon component.
+ * @param color - Accent/theme color token or class.
  * @returns The rendered TaskCard UI.
  * @example
  * <TaskCard title={...}, description={...}, icon={...}, color={...} />

--- a/components/manager/optional-benefits/OptionalBenefits.tsx
+++ b/components/manager/optional-benefits/OptionalBenefits.tsx
@@ -27,8 +27,8 @@ import { useAddBenefit } from "@/hooks/use-add-benefit";
 
 /**
  * Optional Benefit Details component.
- * @param title - See component props.
- * @param value - See component props.
+ * @param title - Section/card title text.
+ * @param value - Primary metric or display value.
  * @returns The rendered OptionalBenefitDetails UI.
  * @example
  * <OptionalBenefitDetails title={...}, value={...} />

--- a/components/manager/optional-benefits/OptionalBenefits.tsx
+++ b/components/manager/optional-benefits/OptionalBenefits.tsx
@@ -26,7 +26,12 @@ import {
 import { useAddBenefit } from "@/hooks/use-add-benefit";
 
 /**
- * Renders the Optional Benefit Details UI.
+ * Optional Benefit Details component.
+ * @param title - See component props.
+ * @param value - See component props.
+ * @returns The rendered OptionalBenefitDetails UI.
+ * @example
+ * <OptionalBenefitDetails title={...}, value={...} />
  */
 export function OptionalBenefitDetails({ title, value }: BenefitDetailsProps) {
     return (
@@ -38,7 +43,10 @@ export function OptionalBenefitDetails({ title, value }: BenefitDetailsProps) {
 }
 
 /**
- * Default export: Optional Benefits Grid.
+ * Optional Benefits Grid presentational component.
+ * @returns The rendered OptionalBenefitsGrid UI.
+ * @example
+ * <OptionalBenefitsGrid />
  */
 export default function OptionalBenefitsGrid() {
     const router = useRouter();

--- a/components/manager/stat-cards/Statcards.tsx
+++ b/components/manager/stat-cards/Statcards.tsx
@@ -7,7 +7,14 @@ import { Users, Clock, DollarSign } from "lucide-react";
 import { formatCurrency } from "@/utils/formatCurrency";
 
 /**
- * Renders the Manager Stat Card UI.
+ * Manager Stat Card presentational component.
+ * @param title - See component props.
+ * @param icon - See component props.
+ * @param value - See component props.
+ * @param description - See component props.
+ * @returns The rendered ManagerStatCard UI.
+ * @example
+ * <ManagerStatCard title={...}, icon={...}, value={...}, description={...} />
  */
 export function ManagerStatCard({ title, icon, value, description }: ManagerStatCardProps) {
     return (
@@ -28,7 +35,12 @@ export function ManagerStatCard({ title, icon, value, description }: ManagerStat
 }
 
 /**
- * Default export: Manager Stat Cards.
+ * Manager Stat Cards presentational component.
+ * @param totalEmployees - See component props.
+ * @param totalAnnualPayroll - See component props.
+ * @returns The rendered ManagerStatCards UI.
+ * @example
+ * // <ManagerStatCards totalEmployees={...}, totalAnnualPayroll={...} />
  */
 export default function ManagerStatCards({ totalEmployees, totalAnnualPayroll }: ManagerStatCardsProps) {
     return (

--- a/components/manager/stat-cards/Statcards.tsx
+++ b/components/manager/stat-cards/Statcards.tsx
@@ -8,10 +8,10 @@ import { formatCurrency } from "@/utils/formatCurrency";
 
 /**
  * Manager Stat Card presentational component.
- * @param title - See component props.
- * @param icon - See component props.
- * @param value - See component props.
- * @param description - See component props.
+ * @param title - Section/card title text.
+ * @param icon - Icon element or icon component.
+ * @param value - Primary metric or display value.
+ * @param description - Supporting description text.
  * @returns The rendered ManagerStatCard UI.
  * @example
  * <ManagerStatCard title={...}, icon={...}, value={...}, description={...} />
@@ -36,8 +36,8 @@ export function ManagerStatCard({ title, icon, value, description }: ManagerStat
 
 /**
  * Manager Stat Cards presentational component.
- * @param totalEmployees - See component props.
- * @param totalAnnualPayroll - See component props.
+ * @param totalEmployees - Collection rendered by this component.
+ * @param totalAnnualPayroll - Component input controlling render behavior.
  * @returns The rendered ManagerStatCards UI.
  * @example
  * // <ManagerStatCards totalEmployees={...}, totalAnnualPayroll={...} />

--- a/components/manager/summary-cards/SummaryCards.tsx
+++ b/components/manager/summary-cards/SummaryCards.tsx
@@ -12,7 +12,14 @@ import { SummaryCardsProps } from "./types";
 import { formatCurrency } from "@/utils/formatCurrency";
 
 /**
- * Renders the Benefit Summary Card UI.
+ * Benefit Summary Card presentational component.
+ * @param title - See component props.
+ * @param icon - See component props.
+ * @param count - See component props.
+ * @param description - See component props.
+ * @returns The rendered BenefitSummaryCard UI.
+ * @example
+ * <BenefitSummaryCard title={...}, icon={...}, count={...}, description={...} />
  */
 export function BenefitSummaryCard({ title, icon, count, description }: BenefitSummaryCardProps) {
     return (
@@ -32,7 +39,13 @@ export function BenefitSummaryCard({ title, icon, count, description }: BenefitS
 }
 
 /**
- * Default export: Summary Cards.
+ * Summary Cards presentational component.
+ * @param companyBenefitsCount - See component props.
+ * @param optionalBenefitsCount - See component props.
+ * @param avgDeductions - See component props.
+ * @returns The rendered SummaryCards UI.
+ * @example
+ * // <SummaryCards companyBenefitsCount={...}, optionalBenefitsCount={...}, avgDeductions={...} />
  */
 export default function SummaryCards({
     companyBenefitsCount,

--- a/components/manager/summary-cards/SummaryCards.tsx
+++ b/components/manager/summary-cards/SummaryCards.tsx
@@ -13,10 +13,10 @@ import { formatCurrency } from "@/utils/formatCurrency";
 
 /**
  * Benefit Summary Card presentational component.
- * @param title - See component props.
- * @param icon - See component props.
- * @param count - See component props.
- * @param description - See component props.
+ * @param title - Section/card title text.
+ * @param icon - Icon element or icon component.
+ * @param count - Component input controlling render behavior.
+ * @param description - Supporting description text.
  * @returns The rendered BenefitSummaryCard UI.
  * @example
  * <BenefitSummaryCard title={...}, icon={...}, count={...}, description={...} />
@@ -40,9 +40,9 @@ export function BenefitSummaryCard({ title, icon, count, description }: BenefitS
 
 /**
  * Summary Cards presentational component.
- * @param companyBenefitsCount - See component props.
- * @param optionalBenefitsCount - See component props.
- * @param avgDeductions - See component props.
+ * @param companyBenefitsCount - Component input controlling render behavior.
+ * @param optionalBenefitsCount - Component input controlling render behavior.
+ * @param avgDeductions - Collection rendered by this component.
  * @returns The rendered SummaryCards UI.
  * @example
  * // <SummaryCards companyBenefitsCount={...}, optionalBenefitsCount={...}, avgDeductions={...} />

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -21,7 +21,10 @@ import { Input } from "@/components/ui/input";
 import { ArrowUpDown, ChevronLeft, ChevronRight } from "lucide-react";
 
 /**
- * Renders the Sortable Header UI.
+ * Sortable Header component.
+ * @returns The rendered SortableHeader UI.
+ * @example
+ * <SortableHeader />
  */
 export function SortableHeader<T>({ column, label }: { column: Column<T, unknown>; label: string }) {
   return (
@@ -48,7 +51,10 @@ interface DataTableProps<T> {
 }
 
 /**
- * Renders the Data Table UI.
+ * Data Table component.
+ * @returns The rendered DataTable UI.
+ * @example
+ * <DataTable />
  */
 export function DataTable<T>({
   columns,

--- a/components/ui/navbars/employee-navbar.tsx
+++ b/components/ui/navbars/employee-navbar.tsx
@@ -113,7 +113,10 @@ const defaultNavigationLinks: EmployeeNavbarNavLink[] = [
 ]
 
 /**
- * Renders the Employee Navbar UI.
+ * Employee Navbar component.
+ * @returns The rendered EmployeeNavbar UI.
+ * @example
+ * <EmployeeNavbar />
  */
 export const EmployeeNavbar = React.forwardRef<HTMLElement, EmployeeNavbarProps>(
   (

--- a/components/ui/navbars/external-search-navbar.tsx
+++ b/components/ui/navbars/external-search-navbar.tsx
@@ -11,7 +11,10 @@ import { ArrowLeft, Moon, Sun } from "lucide-react"
 import { Button } from "@/components/ui/button"
 
 /**
- * Renders the External Search Navbar UI.
+ * External Search Navbar component.
+ * @returns The rendered ExternalSearchNavbar UI.
+ * @example
+ * <ExternalSearchNavbar />
  */
 export function ExternalSearchNavbar() {
   const { theme, setTheme } = useTheme()

--- a/components/ui/navbars/manager-navbar.tsx
+++ b/components/ui/navbars/manager-navbar.tsx
@@ -117,7 +117,10 @@ const defaultNavigationLinks: ManagerNavbarNavLink[] = [
 ]
 
 /**
- * Renders the Manager Navbar UI.
+ * Manager Navbar component.
+ * @returns The rendered ManagerNavbar UI.
+ * @example
+ * <ManagerNavbar />
  */
 export const ManagerNavbar = React.forwardRef<HTMLElement, ManagerNavbarProps>(
   (

--- a/hooks/use-add-benefit.ts
+++ b/hooks/use-add-benefit.ts
@@ -5,7 +5,11 @@ import { useState } from "react"
 import { addBenefit } from "@/lib/supabase/benefits"
 
 /**
- * Hook: use Add Benefit.
+ * React Query mutation hook that inserts a benefits catalog row.
+ * @param initialType - Default benefit type for the dialog form (COMPANY|OPTIONAL).
+ * @returns Mutation helpers plus local form state setters.
+ * @example
+ * const { mutate, isPending } = useAddBenefit("OPTIONAL");
  */
 export function useAddBenefit(initialType: "COMPANY" | "OPTIONAL" = "COMPANY") {
     const [benefit, setBenefit] = useState("")

--- a/hooks/use-add-employee.ts
+++ b/hooks/use-add-employee.ts
@@ -5,7 +5,11 @@ import { useState } from "react"
 import { addEmployee as addEmployeeToDB } from "@/lib/supabase/employee"
 
 /**
- * Hook: use Add Employee.
+ * React Query mutation hook that inserts an employees row.
+ * @returns Mutation helpers for the manager add-employee dialog.
+ * @example
+ * const { mutateAsync } = useAddEmployee();
+ * await mutateAsync(newEmployee);
  */
 export function useAddEmployee() {
     const [firstName, setFirstName] = useState("")

--- a/hooks/use-controlled-state.tsx
+++ b/hooks/use-controlled-state.tsx
@@ -11,7 +11,12 @@ interface CommonControlledStateProps<T> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 /**
- * Hook: use Controlled State.
+ * Controlled/uncontrolled state helper (prop `value` + onChange vs internal state).
+ * Passing `value` (even undefined) makes the state controlled.
+ * @param props - Optional value/defaultValue and onChange rest args.
+ * @returns Tuple of current state and a setter that forwards onChange.
+ * @example
+ * const [open, setOpen] = useControlledState({ value, onChange: setValue });
  */
 export function useControlledState<T, Rest extends any[] = []>(
   props: CommonControlledStateProps<T> & {

--- a/hooks/use-is-in-view.tsx
+++ b/hooks/use-is-in-view.tsx
@@ -16,6 +16,8 @@ interface UseIsInViewOptions {
  * @param ref - Imperative handle target for the observed element.
  * @param options - inView gate, once, and margin forwarded to useInView.
  * @returns Local ref to attach and current isInView flag.
+ * @example
+ * const { ref, isInView } = useIsInView(outerRef, { inView: true, inViewOnce: true });
  */
 function useIsInView<T extends HTMLElement = HTMLElement>(
   ref: React.Ref<T>,

--- a/lib/benefits/eligibility.ts
+++ b/lib/benefits/eligibility.ts
@@ -11,7 +11,7 @@ export interface EligibilityInput {
 }
 
 /**
- * EligibilityResult type/interface.
+ * Outcome of optional-benefits eligibility evaluation.
  */
 export interface EligibilityResult {
   eligible: boolean;
@@ -55,6 +55,10 @@ const EXEMPT_EMPLOYMENT_STATUSES = new Set(["CONTRACTOR", "SEASONAL", "INTERN", 
  * error=true locks enrollment; loading/null hours keep eligible=false with loading.
  * @param employee - Status, hours/week, and state used for thresholds.
  * @returns EligibilityResult with thresholdHours and optional reason/shortMessage.
+ * @example
+ * checkOptionalBenefitsEligibility({
+ *   employmentStatus: "FULL_TIME", hoursPerWeek: 32, state: "NY",
+ * }).eligible // => true
  */
 export function checkOptionalBenefitsEligibility(employee: EligibilityInput): EligibilityResult {
   const rule = (employee.state && STATE_RULES[employee.state.toUpperCase()]) || DEFAULT_STATE_RULE;
@@ -110,6 +114,12 @@ export function checkOptionalBenefitsEligibility(employee: EligibilityInput): El
 
 /**
  * True when checkOptionalBenefitsEligibility(...).eligible — used by runPayroll.
+ * @param employee - Same snapshot shape as eligibility input.
+ * @returns Whether optional benefit deductions should reduce net pay.
+ * @example
+ * shouldApplyOptionalDeductions({
+ *   employmentStatus: "CONTRACTOR", hoursPerWeek: 40, state: "CA",
+ * }) // => false
  */
 export function shouldApplyOptionalDeductions(employee: EligibilityInput): boolean {
   return checkOptionalBenefitsEligibility(employee).eligible;

--- a/lib/get-strict-context.tsx
+++ b/lib/get-strict-context.tsx
@@ -4,7 +4,11 @@
 import * as React from 'react';
 
 /**
- * Get Strict Context.
+ * Factory for a typed React context that throws if used outside its provider.
+ * @param name - Label included in the missing-provider error message.
+ * @returns `[Provider, useSafeContext]` pair.
+ * @example
+ * const [Provider, useCtx] = getStrictContext<Theme>("Theme");
  */
 function getStrictContext<T>(
   name?: string,

--- a/lib/supabase/benefits.ts
+++ b/lib/supabase/benefits.ts
@@ -18,6 +18,11 @@ export type BenefitUpdate = TablesUpdate<"benefits">;
 
 /**
  * Inserts a benefits catalog row (COMPANY or OPTIONAL).
+ * @param company_benefit - Insert payload for the benefits table.
+ * @returns Inserted row data from Supabase.
+ * @throws On Supabase error.
+ * @example
+ * await addBenefit({ name: "Dental", type: "OPTIONAL", monthly_cost: 40 });
  */
 export const addBenefit = async (company_benefit: BenefitInsert) => {
     const supabase = createClient();
@@ -33,6 +38,10 @@ export const addBenefit = async (company_benefit: BenefitInsert) => {
 
 /**
  * Lists benefits where type=COMPANY.
+ * @returns COMPANY benefit rows.
+ * @throws On Supabase error.
+ * @example
+ * const company = await getCompanyBenefits();
  */
 export const getCompanyBenefits = async () => {
     const supabase = createClient();
@@ -52,6 +61,10 @@ export const getCompanyBenefits = async () => {
 
 /**
  * Lists benefits where type=OPTIONAL.
+ * @returns OPTIONAL benefit rows.
+ * @throws On Supabase error.
+ * @example
+ * const optional = await getOptionalBenefits();
  */
 export const getOptionalBenefits = async () => {
     const supabase = createClient();
@@ -71,7 +84,12 @@ export const getOptionalBenefits = async () => {
 
 /**
  * ACTIVE employee_benefits joined to OPTIONAL benefit rows for one employee.
+ * @param employee_id - Target employee UUID.
  * @param supabaseClient - Optional server client (payroll path); else browser client.
+ * @returns Active optional enrollments with nested benefit.
+ * @throws On Supabase error.
+ * @example
+ * const rows = await getActiveOptionalEmployeeBenefits(employeeId, serverClient);
  */
 export const getActiveOptionalEmployeeBenefits = async (employee_id: string, supabaseClient?: SupabaseClient) => {
     const supabase = supabaseClient || createClient();
@@ -98,6 +116,12 @@ export const getActiveOptionalEmployeeBenefits = async (employee_id: string, sup
 /**
  * Upserts enrollment for the current employee on (employee_id, benefit_id).
  * SECURITY: derives employee_id from the auth session.
+ * @param args.benefit_id - Catalog benefit UUID.
+ * @param args.status - ACTIVE or NOT_ENROLLED.
+ * @returns Upsert result from Supabase.
+ * @throws If unauthenticated or Supabase fails.
+ * @example
+ * await upsertEmployeeBenefit({ benefit_id, status: "ACTIVE" });
  */
 export const upsertEmployeeBenefit = async ({
     benefit_id,
@@ -129,6 +153,10 @@ export const upsertEmployeeBenefit = async ({
 
 /**
  * Deletes a benefits catalog row by id.
+ * @param id - Benefits table UUID.
+ * @throws On Supabase error.
+ * @example
+ * await deleteBenefit(benefitId);
  */
 export const deleteBenefit = async (id: string) => {
     const supabase = createClient();
@@ -145,6 +173,12 @@ export const deleteBenefit = async (id: string) => {
 
 /**
  * Updates a benefits catalog row by id.
+ * @param id - Benefits table UUID.
+ * @param updates - Partial benefit fields to patch.
+ * @returns Updated row data.
+ * @throws On Supabase error.
+ * @example
+ * await updateBenefit(id, { monthly_cost: 55 });
  */
 export const updateBenefit = async (id: string, updates: BenefitUpdate) => {
     const supabase = createClient();
@@ -161,6 +195,10 @@ export const updateBenefit = async (id: string, updates: BenefitUpdate) => {
 
 /**
  * Exact count of COMPANY benefits.
+ * @returns Count integer (head-only query).
+ * @throws On Supabase error.
+ * @example
+ * const n = await getCompanyBenefitsCount();
  */
 export const getCompanyBenefitsCount = async () => {
     const supabase = createClient();
@@ -180,6 +218,10 @@ export const getCompanyBenefitsCount = async () => {
 
 /**
  * Exact count of OPTIONAL benefits.
+ * @returns Count integer (head-only query).
+ * @throws On Supabase error.
+ * @example
+ * const n = await getOptionalBenefitsCount();
  */
 export const getOptionalBenefitsCount = async () => {
     const supabase = createClient();

--- a/lib/supabase/employee.tsx
+++ b/lib/supabase/employee.tsx
@@ -11,17 +11,17 @@ type EmployeeInsert = TablesInsert<"employees">;
 
 // Role-based employee types for different access levels
 /**
- * ManagerEmployee type/interface.
+ * Manager-facing employee row shape used by table/forms.
  */
 export type ManagerEmployee = Tables<"employees">;
 
 /**
- * EmployeeSearch type/interface.
+ * Elevated directory search hit including pay/address fields.
  */
 export type EmployeeSearch = Omit<Tables<"employees">, 'address_line' | 'zip_code' | 'city' | 'state' | 'pay_rate' | 'pay_frequency'>;
 
 /**
- * VisitorSearch type/interface.
+ * Visitor-safe directory search hit (no pay/address).
  */
 export type VisitorSearch = Pick<Tables<"employees">, 'id' | 'first_name' | 'last_name' | 'position' | 'phone' | 'email'>;
 
@@ -33,7 +33,11 @@ export type EmployeeWithProfile = ManagerEmployee | EmployeeSearch | VisitorSear
 /**
  * Inserts an employees row.
  * SECURITY: accepts full PII + pay fields.
+ * @param employee - Insert payload including pay/tax/address fields.
+ * @returns Inserted employee row.
  * @throws On Supabase error.
+ * @example
+ * await addEmployee({ first_name: "Ada", pay_rate: 50, pay_frequency: "HOURLY" });
  */
 export const addEmployee = async (employee: EmployeeInsert) => {
     const { error } = await supabase
@@ -49,6 +53,10 @@ export const addEmployee = async (employee: EmployeeInsert) => {
 /**
  * Selects all employees.
  * SECURITY: full rows — manager-only surfaces.
+ * @returns Every employees row (includes pay/PII).
+ * @throws On Supabase error.
+ * @example
+ * const all = await getEmployees();
  */
 export const getEmployees = async () => {
     const { data: employees, error } = await supabase
@@ -65,6 +73,10 @@ export const getEmployees = async () => {
 
 /**
  * Exact count of ACTIVE employees (head-only query).
+ * @returns Active headcount.
+ * @throws On Supabase error.
+ * @example
+ * const active = await getActiveEmployeesCount();
  */
 export const getActiveEmployeesCount = async () => {
     const { count, error } = await supabase
@@ -83,6 +95,10 @@ export const getActiveEmployeesCount = async () => {
 /**
  * Sums estimated annual pay for ACTIVE employees (salary / biweekly×26 / hourly×40×52).
  * SECURITY: aggregates compensation.
+ * @returns Estimated annual payroll total.
+ * @throws On Supabase error.
+ * @example
+ * const annual = await getTotalAnnualPayroll();
  */
 export const getTotalAnnualPayroll = async () => {
     const { data: employees, error } = await supabase
@@ -120,6 +136,12 @@ export const getTotalAnnualPayroll = async () => {
 /**
  * Partial update of an employee by id.
  * SECURITY: may change pay/PII fields.
+ * @param id - Employee UUID.
+ * @param updates - Partial employee fields.
+ * @returns Updated row.
+ * @throws On Supabase error.
+ * @example
+ * await updateEmployee(id, { pay_rate: 55 });
  */
 export const updateEmployee = async (id: string, updates: Partial<EmployeeInsert>) => {
     const { error } = await supabase
@@ -135,6 +157,10 @@ export const updateEmployee = async (id: string, updates: Partial<EmployeeInsert
 
 /**
  * Deletes an employee by id.
+ * @param id - Employee UUID.
+ * @throws On Supabase error.
+ * @example
+ * await deleteEmployee(id);
  */
 export const deleteEmployee = async (id: string) => {
     const { error } = await supabase
@@ -151,7 +177,10 @@ export const deleteEmployee = async (id: string) => {
 /**
  * Resolves auth user → profiles → employees for the signed-in session.
  * SECURITY: returns user, profile, and full employee row.
+ * @returns `{ user, profile, employee }` for the current session.
  * @throws If unauthenticated or profile/employee missing.
+ * @example
+ * const { employee } = await getCurrentEmployee();
  */
 export async function getCurrentEmployee() {
     const {
@@ -192,6 +221,10 @@ export async function getCurrentEmployee() {
 
 /**
  * Maps employees + departments into DirectoryEntry rows (no pay fields).
+ * @returns Directory entries safe for coworker browse UIs.
+ * @throws On Supabase error.
+ * @example
+ * const directory = await getEmployeeDirectory();
  */
 export const getEmployeeDirectory = async (): Promise<DirectoryEntry[]> => {
     const { data: employees, error: employeesError } = await supabase
@@ -233,6 +266,10 @@ export const getEmployeeDirectory = async (): Promise<DirectoryEntry[]> => {
 
 /**
  * Counts employees grouped by department name.
+ * @returns `{ name, count }` rows for charting.
+ * @throws On Supabase error.
+ * @example
+ * const byDept = await getEmployeeByDepartment();
  */
 export const getEmployeeByDepartment = async () => {
     const { data, error } = await supabase
@@ -256,6 +293,10 @@ export const getEmployeeByDepartment = async () => {
 /**
  * Aggregates annualized pay by position for charts.
  * SECURITY: compensation aggregates.
+ * @returns `{ position, total }` annualized aggregates.
+ * @throws On Supabase error.
+ * @example
+ * const byPos = await getEmployeeSalaryByPosition();
  */
 export const getEmployeeSalaryByPosition = async () => {
     const { data, error } = await supabase

--- a/lib/supabase/payroll-actions.ts
+++ b/lib/supabase/payroll-actions.ts
@@ -35,8 +35,14 @@ const weeklyApprovedHours = (entries: Tables<"time_entries">[]): Map<string, num
 
 /**
  * Inserts a PROCESSING payroll_run for the given period.
+ * @param supabase - Server Supabase client.
+ * @param payPeriodStart - Inclusive YYYY-MM-DD.
+ * @param payPeriodEnd - Inclusive YYYY-MM-DD.
  * @param user - Auth user id stored as run_by.
+ * @returns Inserted payroll_runs row.
  * @throws On insert failure.
+ * @example
+ * const run = await insertPayrollRun(supabase, "2026-08-01", "2026-08-14", userId);
  */
 export const insertPayrollRun = async (supabase: SupabaseClient, payPeriodStart: string, payPeriodEnd: string, user: string) => {
     const { data: run, error: runError } = await supabase
@@ -62,6 +68,11 @@ export const insertPayrollRun = async (supabase: SupabaseClient, payPeriodStart:
 /**
  * Loads all employees with employment_status ACTIVE.
  * SECURITY: full employee rows including pay/tax fields.
+ * @param supabase - Server Supabase client.
+ * @returns Active employee rows.
+ * @throws On Supabase error.
+ * @example
+ * const staff = await getActiveEmployees(supabase);
  */
 export const getActiveEmployees = async (supabase: SupabaseClient) => {
     const { data: employees, error: eError } = await supabase
@@ -79,6 +90,13 @@ export const getActiveEmployees = async (supabase: SupabaseClient) => {
 
 /**
  * APPROVED time_entries with work_date in [start, end] inclusive.
+ * @param supabase - Server Supabase client.
+ * @param payPeriodStart - Inclusive YYYY-MM-DD.
+ * @param payPeriodEnd - Inclusive YYYY-MM-DD.
+ * @returns Approved entries in the period.
+ * @throws On Supabase error.
+ * @example
+ * const entries = await getTimeEntriesForPayPeriod(supabase, start, end);
  */
 export const getTimeEntriesForPayPeriod = async (supabase: SupabaseClient, payPeriodStart: string, payPeriodEnd: string) => {
     const { data: time_entries, error: tError } = await supabase
@@ -98,6 +116,11 @@ export const getTimeEntriesForPayPeriod = async (supabase: SupabaseClient, payPe
 
 /**
  * Bulk-inserts computed payroll_records (nulls filtered out).
+ * @param supabase - Server Supabase client.
+ * @param records - Insert-shaped payroll_records (may include null holes).
+ * @throws On Supabase error.
+ * @example
+ * await insertPayrollRecords(supabase, computedRecords);
  */
 export const insertPayrollRecords = async (supabase: SupabaseClient, records: TablesInsert<"payroll_records">[]) => {
     const { error: rError } = await supabase
@@ -112,7 +135,14 @@ export const insertPayrollRecords = async (supabase: SupabaseClient, records: Ta
 
 /**
  * Aggregates record totals onto the run and sets status COMPLETED.
+ * @param supabase - Server Supabase client.
+ * @param records - Inserted/computed records used for totals.
+ * @param payroll_run - Run row being finalized.
+ * @param user - Auth user id for audit fields.
  * @returns Fixed-string totals for gross, net, and taxes.
+ * @throws On update failure.
+ * @example
+ * await updatePayrollRun(supabase, records, run, userId);
  */
 export const updatePayrollRun = async (supabase: SupabaseClient, records: TablesInsert<"payroll_records">[], payroll_run: Tables<"payroll_runs">, user: string) => {
     const valid_records = records.filter((r): r is NonNullable<typeof r> => !!r);
@@ -157,6 +187,8 @@ export const updatePayrollRun = async (supabase: SupabaseClient, records: Tables
  * @param payPeriodStart - Inclusive YYYY-MM-DD.
  * @param payPeriodEnd - Inclusive YYYY-MM-DD.
  * @throws If unauthenticated, dates invalid, or period already run.
+ * @example
+ * await runPayroll("2026-08-01", "2026-08-14");
  */
 export const runPayroll = async (payPeriodStart: string, payPeriodEnd: string) => {
     const supabase = await createClient();

--- a/lib/supabase/payroll.tsx
+++ b/lib/supabase/payroll.tsx
@@ -13,7 +13,10 @@ const roundMoney = (value: number) => Math.round((value + Number.EPSILON) * 100)
 
 /**
  * Fetches all payroll_runs rows.
+ * @returns Payroll run list for manager tables/charts.
  * @throws Relays Supabase errors after console.error.
+ * @example
+ * const runs = await getPayrollRuns();
  */
 export const getPayrollRuns = async () => {
     const { data: payroll_runs, error } = await supabase
@@ -31,7 +34,10 @@ export const getPayrollRuns = async () => {
 /**
  * Fetches payroll_records with joined employee name + pay_frequency.
  * SECURITY: includes compensation fields — manager-facing.
+ * @returns Records with nested employee display fields.
  * @throws Relays Supabase errors.
+ * @example
+ * const records = await getPayrollRecords();
  */
 export const getPayrollRecords = async () => {
     const { data: payroll_records, error } = await supabase
@@ -54,6 +60,15 @@ function getWeekStartKey(date: Date): string {
     return d.toISOString().slice(0, 10);
 }
 
+/**
+ * Buckets approved hours into Mon–Sun UTC weeks and applies 1.5× OT after 40h/week.
+ * @param entries - Time entries for one employee (work_date + hours_worked).
+ * @param pay_rate - Hourly rate used for regular and OT gross.
+ * @returns Aggregated regularHours, overtimeHours, and gross_pay.
+ * @example
+ * computeWeeklyOvertime([{ work_date: "2026-08-10", hours_worked: 45 }], 20)
+ * // => { regularHours: 40, overtimeHours: 5, gross_pay: 950 }
+ */
 function computeWeeklyOvertime(
     entries: Tables<"time_entries">[],
     pay_rate: number
@@ -93,6 +108,8 @@ function computeWeeklyOvertime(
  * @param payroll_run - Parent run (id stamped onto the result).
  * @param benefitDeduction - Monthly optional/company deduction total (default 0).
  * @returns Insert-shaped record fields (hours, taxes, net_pay).
+ * @example
+ * const row = calculatePayRollForEmployee(employee, entries, run, 200);
  */
 export const calculatePayRollForEmployee = (
     employee: Tables<"employees">,
@@ -148,7 +165,10 @@ export const calculatePayRollForEmployee = (
 
 /**
  * Average benefit_deductions across the latest 6 payroll_records (by period start).
- * @returns 0 when no records exist.
+ * @returns Mean deduction amount, or 0 when no records exist.
+ * @throws On Supabase error.
+ * @example
+ * const avg = await getAverageBenefitDeductions();
  */
 export const getAverageBenefitDeductions = async () => {
     const supabase = createClient()

--- a/lib/supabase/paystubs.ts
+++ b/lib/supabase/paystubs.ts
@@ -9,6 +9,10 @@ import { getCurrentEmployee } from "./employee";
 /**
  * Payroll records for the current employee with nested run + employee fields.
  * SECURITY: compensation and address PII for the authenticated employee.
+ * @returns Paystub source rows for the signed-in employee.
+ * @throws If unauthenticated or Supabase fails.
+ * @example
+ * const stubs = await getEmployeePaystubs();
  */
 export async function getEmployeePaystubs() {
 	const supabase = createClient();

--- a/lib/supabase/time-entries.ts
+++ b/lib/supabase/time-entries.ts
@@ -15,7 +15,10 @@ const ELIGIBILITY_LOOKBACK_WEEKS = 4
  * Inserts a PENDING time entry for the current employee.
  * @param workDate - YYYY-MM-DD.
  * @param hoursWorked - Non-negative finite hours.
+ * @returns Inserted time_entries row.
  * @throws On validation or Supabase failure.
+ * @example
+ * await createTimeEntry("2026-08-12", 8);
  */
 export const createTimeEntry = async (workDate: string, hoursWorked: number) => {
   const supabase = createClient()
@@ -52,6 +55,10 @@ export const createTimeEntry = async (workDate: string, hoursWorked: number) => 
 
 /**
  * Latest 5 time entries for the current employee (newest work_date first).
+ * @returns Up to five recent entries for dashboard cards.
+ * @throws If unauthenticated or Supabase fails.
+ * @example
+ * const recent = await getRecentTimeEntries();
  */
 export const getRecentTimeEntries = async () => {
   const supabase = createClient()
@@ -74,6 +81,11 @@ export const getRecentTimeEntries = async () => {
 /**
  * Max approved hours in any single Mon–Sun UTC week over the last 4 weeks
  * (including the current week). Used as hoursPerWeek for eligibility.
+ * @param referenceDate - Anchor instant (defaults to now).
+ * @returns Peak weekly approved hours in the lookback window.
+ * @throws If unauthenticated or Supabase fails.
+ * @example
+ * const hours = await getApprovedHoursWorked(new Date("2026-08-13"));
  */
 export const getApprovedHoursWorked = async (referenceDate?: Date): Promise<number> => {
   const supabase = createClient()

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,6 +6,10 @@ import { twMerge } from "tailwind-merge"
 
 /**
  * Merges class names with clsx + tailwind-merge.
+ * @param inputs - Class values (strings, arrays, conditionals).
+ * @returns Single class string with Tailwind conflicts resolved.
+ * @example
+ * cn("px-2", false && "hidden", "px-4") // => "px-4"
  */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -13,6 +17,10 @@ export function cn(...inputs: ClassValue[]) {
 
 /**
  * Short weekday label for a Date (en-US).
+ * @param date - Instant to format.
+ * @returns Abbreviated weekday (e.g. "Mon").
+ * @example
+ * getShortDay(new Date("2026-08-10T12:00:00")) // => "Mon"
  */
 export function getShortDay(date: Date) {
   return new Intl.DateTimeFormat("en-US", { weekday: "short" }).format(date)
@@ -20,6 +28,11 @@ export function getShortDay(date: Date) {
 
 /**
  * Formats start/end date-only strings as "Mon D–Mon D, YYYY" (noon-anchored).
+ * @param start - Inclusive period start (YYYY-MM-DD), or nullish.
+ * @param end - Inclusive period end (YYYY-MM-DD), or nullish.
+ * @returns Formatted range, or "Unknown period" when either bound is missing.
+ * @example
+ * formatPayPeriod("2026-08-01", "2026-08-14") // => "Aug 1–Aug 14, 2026"
  */
 export function formatPayPeriod(start?: string | null, end?: string | null) {
   if (!start || !end) return "Unknown period"
@@ -43,6 +56,10 @@ export function formatPayPeriod(start?: string | null, end?: string | null) {
 
 /**
  * Formats a paid-on date string; noon-anchors date-only values to avoid TZ shifts.
+ * @param date - ISO or YYYY-MM-DD paid-on value.
+ * @returns Locale short date, or "Unknown" when falsy.
+ * @example
+ * formatPaidOn("2026-08-15") // => "Aug 15, 2026"
  */
 export function formatPaidOn(date?: string | null) {
   if (!date) return "Unknown"

--- a/lib/utils/date-helpers.ts
+++ b/lib/utils/date-helpers.ts
@@ -8,6 +8,8 @@
  * per-week eligibility window agree on the workweek boundary.
  * @param date - Instant or date-only/ISO string (defaults to now).
  * @returns Monday 00:00:00.000Z for that week.
+ * @example
+ * getWeekStartUTC("2026-08-13").toISOString().slice(0, 10) // => "2026-08-10"
  */
 export function getWeekStartUTC(date: Date | string = new Date()): Date {
   const d = typeof date === "string" ? new Date(date) : date;
@@ -24,6 +26,8 @@ export function getWeekStartUTC(date: Date | string = new Date()): Date {
  * ISO date key (YYYY-MM-DD) of the Monday that starts the UTC week for `date`.
  * @param date - Instant or date-only/ISO string (defaults to now).
  * @returns Week-start key used as Map keys in overtime/eligibility bucketing.
+ * @example
+ * getWeekStartKey("2026-08-13") // => "2026-08-10"
  */
 export function getWeekStartKey(date: Date | string = new Date()): string {
   return getWeekStartUTC(date).toISOString().slice(0, 10);

--- a/utils/formatCurrency.ts
+++ b/utils/formatCurrency.ts
@@ -1,5 +1,9 @@
 /**
  * USD currency formatter for payroll/UI display.
+ * @param value - Numeric amount (not pre-scaled cents).
+ * @returns Locale currency string (en-US, USD).
+ * @example
+ * formatCurrency(1234.5) // => "$1,234.50"
  */
 export function formatCurrency(value: number): string {
     return new Intl.NumberFormat("en-US", {

--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -17,6 +17,10 @@ if (!supabaseKey || !supabaseUrl) {
 /**
  * Returns a typed browser Supabase client.
  * SECURITY: uses the publishable anon key only.
+ * @returns Browser client bound to NEXT_PUBLIC_SUPABASE_* env.
+ * @example
+ * const supabase = createClient();
+ * const { data } = await supabase.from("employees").select("id");
  */
 export const createClient = () =>
     createBrowserClient<Database>(

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -12,7 +12,11 @@ const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
 /**
  * Builds a server Supabase client bound to the request cookie store.
  * SECURITY: session cookies — never log cookie values.
+ * @returns Promise of a cookie-aware Supabase client.
  * @throws If Supabase env vars are missing.
+ * @example
+ * const supabase = await createClient();
+ * const { data: { user } } = await supabase.auth.getUser();
  */
 export async function createClient() {
 


### PR DESCRIPTION
## Summary
- Gap-fill ENGINEERING-PRINCIPLES §10 after PR #190: add `@param` / `@returns` / `@example` on non-trivial helpers, Supabase data-layer exports, hooks, and custom employee/manager UI.
- Preserve all `SECURITY:` markers on payroll/auth/PII surfaces and keep `TODO(#186–#189)` links unchanged.
- Docs-only (63 files, under the ~90-file CodeRabbit split threshold).

## Test plan
- [x] `npm run test:run` — 206 passed, 39 skipped
- [x] `npm run build` — success (placeholder Supabase env)
- [ ] CI Build + Lint Code Base green
- [ ] `/code-review` vs `main`; address VALID findings

Co-authored-by: Claude <noreply@anthropic.com>

Made with [Cursor](https://cursor.com)