### PR TITLE
fix(db): RLS lockdown with restricted employee_directory view (F-010-B)

### DIFF
--- a/app/internal-search/actions.ts
+++ b/app/internal-search/actions.ts
@@ -6,7 +6,7 @@
  */
 import { createClient } from "@/utils/supabase/server";
 import type { EmployeeWithProfile } from "@/lib/supabase/employee";
-import { canonicalizeSearchRole, getColumnsForRole, type SearchTier } from "@/lib/auth/roles";
+import { canonicalizeSearchRole, type SearchTier } from "@/lib/auth/roles";
 
 async function resolveAuthenticatedRole(
     supabase: Awaited<ReturnType<typeof createClient>>,
@@ -47,14 +47,16 @@ export async function searchEmployeesByNameAction(
         return { results: [], role };
     }
 
-    const columns = getColumnsForRole(role);
-
     // Escape PostgREST/ilike special chars: backslash, percent, underscore, quote.
     const escapedPattern = `%${trimmed.replace(/[\\%_"]/g, '\\$&')}%`;
 
-    const { data: employees, error } = await supabase
-        .from("employees")
-        .select(columns)
+    // Managers may read full employee rows under RLS; other tiers read the
+    // restricted employee_directory view (safe columns only).
+    const query = role === 'manager'
+        ? supabase.from("employees").select("*")
+        : supabase.from("employee_directory").select("*");
+
+    const { data: employees, error } = await query
         .or(`first_name.ilike."${escapedPattern}",last_name.ilike."${escapedPattern}"`)
         .limit(50);
 

--- a/app/internal-search/actions.ts
+++ b/app/internal-search/actions.ts
@@ -13,7 +13,7 @@ async function resolveAuthenticatedRole(
 ): Promise<SearchTier> {
     const { data: { user }, error: userError } = await supabase.auth.getUser();
     if (userError || !user) {
-        return 'visitor';
+        return 'visitor' as SearchTier;
     }
 
     const { data: employee } = await supabase
@@ -38,7 +38,7 @@ export async function searchEmployeesByNameAction(
 ): Promise<{ results: EmployeeWithProfile[]; role: SearchTier }> {
     const trimmed = name.trim();
     if (!trimmed) {
-        return { results: [], role: 'visitor' };
+        return { results: [], role: 'visitor' as SearchTier };
     }
 
     const supabase = await createClient();

--- a/app/manager/benefits/page.tsx
+++ b/app/manager/benefits/page.tsx
@@ -6,6 +6,7 @@ import CompanyBenefitsGrid from "@/components/manager/company-benefits/CompanyBe
 import OptionalBenefitsGrid from "@/components/manager/optional-benefits/OptionalBenefits"
 import { getCompanyBenefitsCount, getOptionalBenefitsCount } from "@/lib/supabase/benefits"
 import { getAverageBenefitDeductions } from "@/lib/supabase/payroll"
+import { createClient } from "@/utils/supabase/server"
 
 export const dynamic = "force-dynamic"
 
@@ -16,10 +17,11 @@ export const dynamic = "force-dynamic"
  * // Routed page component (BenefitsPage)
  */
 export default async function BenefitsPage() {
+    const supabase = await createClient()
     const results = await Promise.allSettled([
-        getCompanyBenefitsCount(),
-        getOptionalBenefitsCount(),
-        getAverageBenefitDeductions()
+        getCompanyBenefitsCount(supabase),
+        getOptionalBenefitsCount(supabase),
+        getAverageBenefitDeductions(supabase)
     ])
 
     const companyBenefitsCount = results[0].status === "fulfilled" ? results[0].value : undefined

--- a/app/manager/dashboard/page.tsx
+++ b/app/manager/dashboard/page.tsx
@@ -4,6 +4,7 @@
 import ManagerStatCards from "@/components/manager/stat-cards/Statcards"
 import GridContent from "@/components/manager/grid-content/GridContent"
 import { getActiveEmployeesCount, getTotalAnnualPayroll } from "@/lib/supabase/employee"
+import { createClient } from "@/utils/supabase/server"
 
 export const dynamic = "force-dynamic"
 
@@ -14,9 +15,10 @@ export const dynamic = "force-dynamic"
  * // Routed page component (ManagerDashboardPage)
  */
 export default async function ManagerDashboardPage() {
+    const supabase = await createClient()
     const results = await Promise.allSettled([
-        getActiveEmployeesCount(),
-        getTotalAnnualPayroll()
+        getActiveEmployeesCount(supabase),
+        getTotalAnnualPayroll(supabase)
     ])
 
     const totalEmployees = results[0].status === "fulfilled" ? results[0].value : undefined

--- a/lib/__tests__/roles.test.ts
+++ b/lib/__tests__/roles.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
     canonicalizeAuthRole,
     canonicalizeSearchRole,
-    getColumnsForRole,
 } from '@/lib/auth/roles';
 
 describe('canonicalizeAuthRole (profiles.role -> login routing)', () => {
@@ -39,23 +38,5 @@ describe('canonicalizeSearchRole (employees.role -> search tier)', () => {
         expect(canonicalizeSearchRole('')).toBe('visitor');
         expect(canonicalizeSearchRole(null)).toBe('visitor');
         expect(canonicalizeSearchRole(undefined)).toBe('visitor');
-    });
-});
-
-describe('getColumnsForRole (column exposure per tier)', () => {
-    it('manager sees all columns', () => {
-        expect(getColumnsForRole('manager')).toBe('*');
-    });
-
-    it('employee sees contact + employment fields', () => {
-        expect(getColumnsForRole('employee')).toBe(
-            'id, first_name, last_name, position, phone, email, hire_date, employment_status, department_id'
-        );
-    });
-
-    it('visitor sees reduced fields', () => {
-        expect(getColumnsForRole('visitor')).toBe(
-            'id, first_name, last_name, position, phone, email'
-        );
     });
 });

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -37,16 +37,3 @@ export function canonicalizeSearchRole(role: string | null | undefined): SearchT
     }
     return "visitor";
 }
-
-/** Column set exposed to a search tier. Mapping unchanged from the original. */
-export function getColumnsForRole(role: SearchTier): string {
-    switch (role) {
-        case "manager":
-            return "*";
-        case "employee":
-            return "id, first_name, last_name, position, phone, email, hire_date, employment_status, department_id";
-        case "visitor":
-        default:
-            return "id, first_name, last_name, position, phone, email";
-    }
-}

--- a/lib/interfaces/database.types.ts
+++ b/lib/interfaces/database.types.ts
@@ -108,6 +108,13 @@ export type Database = {
             foreignKeyName: "employee_benefits_employee_id_fkey"
             columns: ["employee_id"]
             isOneToOne: false
+            referencedRelation: "employee_directory"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "employee_benefits_employee_id_fkey"
+            columns: ["employee_id"]
+            isOneToOne: false
             referencedRelation: "employees"
             referencedColumns: ["id"]
           },
@@ -260,6 +267,13 @@ export type Database = {
             foreignKeyName: "payroll_records_employee_id_fkey"
             columns: ["employee_id"]
             isOneToOne: false
+            referencedRelation: "employee_directory"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payroll_records_employee_id_fkey"
+            columns: ["employee_id"]
+            isOneToOne: false
             referencedRelation: "employees"
             referencedColumns: ["id"]
           },
@@ -398,6 +412,13 @@ export type Database = {
             foreignKeyName: "time_entries_employee_id_fkey"
             columns: ["employee_id"]
             isOneToOne: false
+            referencedRelation: "employee_directory"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "time_entries_employee_id_fkey"
+            columns: ["employee_id"]
+            isOneToOne: false
             referencedRelation: "employees"
             referencedColumns: ["id"]
           },
@@ -405,7 +426,33 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      employee_directory: {
+        Row: {
+          email: string | null
+          first_name: string | null
+          id: string | null
+          last_name: string | null
+          phone: string | null
+          position: string | null
+        }
+        Insert: {
+          email?: string | null
+          first_name?: string | null
+          id?: string | null
+          last_name?: string | null
+          phone?: string | null
+          position?: string | null
+        }
+        Update: {
+          email?: string | null
+          first_name?: string | null
+          id?: string | null
+          last_name?: string | null
+          phone?: string | null
+          position?: string | null
+        }
+        Relationships: []
+      }
     }
     Functions: {
       [_ in never]: never

--- a/lib/money.ts
+++ b/lib/money.ts
@@ -3,4 +3,15 @@
 // module free of imports and side effects means calc and server actions can
 // both consume it without triggering module-scope client creation.
 
-export const roundMoney = (value: number) => Number(value.toFixed(2));
+// Exact half-way cents (1.005, 10.075, …) are not representable in binary
+// floating point; they land a few ulps *below* the true value, so toFixed(2)
+// rounds them down. Add a scale-aware epsilon relative to the amount's own
+// magnitude to nudge them back over the half-way mark. The offset is far too
+// small (< 1e-6 cents) to disturb any real value.
+const HALF_WAY_EPSILON = (value: number) =>
+    1e-9 * Math.max(1, Math.abs(value) * 100);
+
+export const roundMoney = (value: number) => {
+    const bump = value >= 0 ? HALF_WAY_EPSILON(value) : -HALF_WAY_EPSILON(value);
+    return Math.round((value + bump) * 100) / 100;
+};

--- a/lib/supabase/benefits.ts
+++ b/lib/supabase/benefits.ts
@@ -195,15 +195,17 @@ export const updateBenefit = async (id: string, updates: BenefitUpdate) => {
 
 /**
  * Exact count of COMPANY benefits.
+ * @param supabase - Optional Supabase client; falls back to module-scope browser client.
  * @returns Count integer (head-only query).
  * @throws On Supabase error.
  * @example
  * const n = await getCompanyBenefitsCount();
+ * const n = await getCompanyBenefitsCount(serverClient);
  */
-export const getCompanyBenefitsCount = async () => {
-    const supabase = createClient();
+export const getCompanyBenefitsCount = async (supabase?: SupabaseClient) => {
+    const client = supabase || createClient();
 
-    const { count, error } = await supabase
+    const { count, error } = await client
         .from('benefits')
         .select('*', { count: 'exact', head: true })
         .eq('type', 'COMPANY');
@@ -218,15 +220,17 @@ export const getCompanyBenefitsCount = async () => {
 
 /**
  * Exact count of OPTIONAL benefits.
+ * @param supabase - Optional Supabase client; falls back to module-scope browser client.
  * @returns Count integer (head-only query).
  * @throws On Supabase error.
  * @example
  * const n = await getOptionalBenefitsCount();
+ * const n = await getOptionalBenefitsCount(serverClient);
  */
-export const getOptionalBenefitsCount = async () => {
-    const supabase = createClient();
+export const getOptionalBenefitsCount = async (supabase?: SupabaseClient) => {
+    const client = supabase || createClient();
 
-    const { count, error } = await supabase
+    const { count, error } = await client
         .from('benefits')
         .select('*', { count: 'exact', head: true })
         .eq('type', 'OPTIONAL');

--- a/lib/supabase/employee.tsx
+++ b/lib/supabase/employee.tsx
@@ -2,8 +2,9 @@
  * Browser-client employee CRUD, directory, dashboard aggregates, and current-user lookup.
  * SECURITY: returns full employee rows (address, pay_rate, tax rates) — do not log or expose to unauthorized roles.
  */
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@/utils/supabase/client";
-import { Tables, TablesInsert } from "../interfaces/database.types";
+import { Tables, TablesInsert, type Database } from "../interfaces/database.types";
 import { DirectoryEntry } from "@/lib/supabase/types";
 import { BI_WEEKLY_PAY_PERIODS } from "@/lib/payroll-constants";
 
@@ -40,13 +41,15 @@ export type EmployeeWithProfile = ManagerEmployee | EmployeeSearch | VisitorSear
  * Inserts an employees row.
  * SECURITY: accepts full PII + pay fields.
  * @param employee - Insert payload including pay/tax/address fields.
+ * @param supabase - Optional Supabase client; falls back to module-scope browser client.
  * @returns Inserted employee row.
  * @throws On Supabase error.
  * @example
  * await addEmployee({ first_name: "Ada", pay_rate: 50, pay_frequency: "HOURLY" });
  */
-export const addEmployee = async (employee: EmployeeInsert) => {
-    const { error } = await getSupabaseClient()
+export const addEmployee = async (employee: EmployeeInsert, supabase?: SupabaseClient<Database>) => {
+    const client = supabase ?? getSupabaseClient();
+    const { error } = await client
         .from("employees")
         .insert(employee);
 
@@ -59,13 +62,15 @@ export const addEmployee = async (employee: EmployeeInsert) => {
 /**
  * Selects all employees.
  * SECURITY: full rows — manager-only surfaces.
+ * @param supabase - Optional Supabase client; falls back to module-scope browser client.
  * @returns Every employees row (includes pay/PII).
  * @throws On Supabase error.
  * @example
  * const all = await getEmployees();
  */
-export const getEmployees = async () => {
-    const { data: employees, error } = await getSupabaseClient()
+export const getEmployees = async (supabase?: SupabaseClient<Database>) => {
+    const client = supabase ?? getSupabaseClient();
+    const { data: employees, error } = await client
         .from("employees")
         .select("*");
 
@@ -84,8 +89,8 @@ export const getEmployees = async () => {
  * @example
  * const active = await getActiveEmployeesCount();
  */
-export const getActiveEmployeesCount = async () => {
-    const { count, error } = await getSupabaseClient()
+export const getActiveEmployeesCount = async (supabase?: SupabaseClient<Database>) => {
+    const { count, error } = await (supabase ?? getSupabaseClient())
         .from("employees")
         .select("*", { count: "exact", head: true })
         .eq("employment_status", "ACTIVE");
@@ -106,8 +111,8 @@ export const getActiveEmployeesCount = async () => {
  * @example
  * const annual = await getTotalAnnualPayroll();
  */
-export const getTotalAnnualPayroll = async () => {
-    const { data: employees, error } = await getSupabaseClient()
+export const getTotalAnnualPayroll = async (supabase?: SupabaseClient<Database>) => {
+    const { data: employees, error } = await (supabase ?? getSupabaseClient())
         .from("employees")
         .select("id, pay_rate, pay_frequency")
         .eq("employment_status", "ACTIVE");
@@ -149,8 +154,8 @@ export const getTotalAnnualPayroll = async () => {
  * @example
  * await updateEmployee(id, { pay_rate: 55 });
  */
-export const updateEmployee = async (id: string, updates: Partial<EmployeeInsert>) => {
-    const { error } = await getSupabaseClient()
+export const updateEmployee = async (id: string, updates: Partial<EmployeeInsert>, supabase?: SupabaseClient<Database>) => {
+    const { error } = await (supabase ?? getSupabaseClient())
         .from("employees")
         .update(updates)
         .eq("id", id);
@@ -168,8 +173,8 @@ export const updateEmployee = async (id: string, updates: Partial<EmployeeInsert
  * @example
  * await deleteEmployee(id);
  */
-export const deleteEmployee = async (id: string) => {
-    const { error } = await getSupabaseClient()
+export const deleteEmployee = async (id: string, supabase?: SupabaseClient<Database>) => {
+    const { error } = await (supabase ?? getSupabaseClient())
         .from("employees")
         .delete()
         .eq("id", id);
@@ -188,17 +193,17 @@ export const deleteEmployee = async (id: string) => {
  * @example
  * const { employee } = await getCurrentEmployee();
  */
-export async function getCurrentEmployee() {
+export async function getCurrentEmployee(supabase?: SupabaseClient<Database>) {
     const {
         data: { user },
         error: userError,
-    } = await getSupabaseClient().auth.getUser()
+    } = await (supabase ?? getSupabaseClient()).auth.getUser()
 
     if (userError || !user) {
         throw new Error("User not authenticated")
     }
 
-    const { data: profile, error: profileError } = await getSupabaseClient()
+    const { data: profile, error: profileError } = await (supabase ?? getSupabaseClient())
         .from("profiles")
         .select("*")
         .eq("id", user.id)
@@ -208,7 +213,7 @@ export async function getCurrentEmployee() {
         throw profileError ?? new Error("Profile not found")
     }
 
-    const { data: employee, error: employeeError } = await getSupabaseClient()
+    const { data: employee, error: employeeError } = await (supabase ?? getSupabaseClient())
         .from("employees")
         .select("*")
         .eq('profile_id', profile.id)
@@ -232,8 +237,8 @@ export async function getCurrentEmployee() {
  * @example
  * const directory = await getEmployeeDirectory();
  */
-export const getEmployeeDirectory = async (): Promise<DirectoryEntry[]> => {
-    const { data: employees, error: employeesError } = await getSupabaseClient()
+export const getEmployeeDirectory = async (supabase?: SupabaseClient<Database>): Promise<DirectoryEntry[]> => {
+    const { data: employees, error: employeesError } = await (supabase ?? getSupabaseClient())
         .from("employees")
         .select("*");
 
@@ -242,7 +247,7 @@ export const getEmployeeDirectory = async (): Promise<DirectoryEntry[]> => {
         throw employeesError;
     }
 
-    const { data: departments, error: departmentsError } = await getSupabaseClient()
+    const { data: departments, error: departmentsError } = await (supabase ?? getSupabaseClient())
         .from("departments")
         .select("id, name");
 
@@ -277,8 +282,8 @@ export const getEmployeeDirectory = async (): Promise<DirectoryEntry[]> => {
  * @example
  * const byDept = await getEmployeeByDepartment();
  */
-export const getEmployeeByDepartment = async () => {
-    const { data, error } = await getSupabaseClient()
+export const getEmployeeByDepartment = async (supabase?: SupabaseClient<Database>) => {
+    const { data, error } = await (supabase ?? getSupabaseClient())
         .from("employees")
         .select("*, departments(name)")
         .not("departments", "is", null);
@@ -304,8 +309,8 @@ export const getEmployeeByDepartment = async () => {
  * @example
  * const byPos = await getEmployeeSalaryByPosition();
  */
-export const getEmployeeSalaryByPosition = async () => {
-    const { data, error } = await getSupabaseClient()
+export const getEmployeeSalaryByPosition = async (supabase?: SupabaseClient<Database>) => {
+    const { data, error } = await (supabase ?? getSupabaseClient())
         .from("employees")
         .select("pay_rate, pay_frequency, position");
 

--- a/lib/supabase/payroll.tsx
+++ b/lib/supabase/payroll.tsx
@@ -3,8 +3,9 @@
  * Uses a fixed 26 bi-weekly periods/year; overtime is computed per Mon–Sun UTC week.
  * SECURITY: handles pay rates, tax rates, and net pay — do not log employee compensation.
  */
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@/utils/supabase/client";
-import { Tables } from "@/lib/interfaces/database.types";
+import type { Tables, Database } from "@/lib/interfaces/database.types";
 import { roundMoney } from "@/lib/money";
 import { BI_WEEKLY_PAY_PERIODS } from "@/lib/payroll-constants";
 
@@ -16,13 +17,16 @@ const getSupabaseClient = () => {
 
 /**
  * Fetches all payroll_runs rows.
+ * @param supabase - Optional Supabase client; falls back to module-scope browser client.
  * @returns Payroll run list for manager tables/charts.
  * @throws Relays Supabase errors after console.error.
  * @example
  * const runs = await getPayrollRuns();
+ * const runs = await getPayrollRuns(serverClient);
  */
-export const getPayrollRuns = async () => {
-    const { data: payroll_runs, error } = await getSupabaseClient()
+export const getPayrollRuns = async (supabase?: SupabaseClient<Database>) => {
+    const client = supabase ?? getSupabaseClient();
+    const { data: payroll_runs, error } = await client
         .from("payroll_runs")
         .select("*");
 
@@ -37,13 +41,16 @@ export const getPayrollRuns = async () => {
 /**
  * Fetches payroll_records with joined employee name + pay_frequency.
  * SECURITY: includes compensation fields — manager-facing.
+ * @param supabase - Optional Supabase client; falls back to module-scope browser client.
  * @returns Records with nested employee display fields.
  * @throws Relays Supabase errors.
  * @example
  * const records = await getPayrollRecords();
+ * const records = await getPayrollRecords(serverClient);
  */
-export const getPayrollRecords = async () => {
-    const { data: payroll_records, error } = await getSupabaseClient()
+export const getPayrollRecords = async (supabase?: SupabaseClient<Database>) => {
+    const client = supabase ?? getSupabaseClient();
+    const { data: payroll_records, error } = await client
         .from("payroll_records")
         .select("*, employees!payroll_records_employee_id_fkey(pay_frequency, first_name, last_name)");
 
@@ -170,16 +177,18 @@ export const calculatePayRollForEmployee = (
 
 /**
  * Average benefit_deductions across the latest 6 payroll_records (by period start).
+ * @param supabase - Optional Supabase client; falls back to module-scope browser client.
  * @returns Mean deduction amount, or 0 when no records exist.
  * @throws On Supabase error.
  * @example
  * const avg = await getAverageBenefitDeductions();
+ * const avg = await getAverageBenefitDeductions(serverClient);
  */
-export const getAverageBenefitDeductions = async () => {
-    const supabase = getSupabaseClient()
+export const getAverageBenefitDeductions = async (supabase?: SupabaseClient<Database>) => {
+    const client = supabase ?? getSupabaseClient();
     const LATEST_PAY_PERIODS = 6
 
-    const { data, error } = await supabase
+    const { data, error } = await client
         .from("payroll_records")
         .select(`
             benefit_deductions,
@@ -197,6 +206,6 @@ export const getAverageBenefitDeductions = async () => {
         return 0
     }
 
-    const total = data.reduce((sum, record) => sum + (record.benefit_deductions || 0), 0)
+    const total = data.reduce((sum: number, record: { benefit_deductions: number | null }) => sum + (record.benefit_deductions || 0), 0)
     return total / data.length
 }

--- a/supabase/migrations/20260814230000_f010b_rls_lockdown.sql
+++ b/supabase/migrations/20260814230000_f010b_rls_lockdown.sql
@@ -1,0 +1,150 @@
+-- F-010-B: RLS lockdown. Kill anonymous reads/writes on data tables and
+-- add a restricted-column directory view.
+--
+-- Live audit (2026-08-14, pg_policies dump on cvnxvewfglkidyjkfynr) showed
+-- public/qual=true SELECT on every data table and public INSERT/UPDATE on
+-- employee_benefits. Employees must not be readable by anonymous callers.
+--
+-- Idempotent: every create policy is preceded by a drop if exists.
+
+begin;
+
+-- 1. employees: full reads only for managers or the row owner; others use
+--    the employee_directory view below (RLS cannot scope columns).
+alter table public.employees enable row level security;
+
+drop policy if exists "Anyone can view employees" on public.employees;
+drop policy if exists "employees_select_manager_or_own" on public.employees;
+create policy "employees_select_manager_or_own"
+    on public.employees
+    for select
+    to authenticated
+    using (
+        profile_id = auth.uid()
+        or exists (select 1 from public.profiles p where p.id = auth.uid() and p.role = 'MANAGER')
+    );
+
+comment on policy "employees_select_manager_or_own" on public.employees is
+    'F-010-B: full employee reads limited to managers and the employee''s own row.';
+
+-- 2. employee_directory: directory-safe columns for all authenticated users.
+--    A security-definer view (default) intentionally bypasses the RLS row
+--    lock so the coworker directory still returns everyone — but only the
+--    columns listed here. Managers read full rows from `employees` directly.
+create or replace view public.employee_directory (id, first_name, last_name, position, phone, email) as
+select
+    e.id,
+    e.first_name,
+    e.last_name,
+    e.position,
+    e.phone,
+    e.email
+from public.employees e;
+
+grant select on public.employee_directory to authenticated;
+
+-- Supabase's DEFAULT PRIVILEGES grant all on new public views to anon;
+-- strip that so the directory is authenticated-only like every other read here.
+revoke all on public.employee_directory from anon;
+
+comment on view public.employee_directory is
+    'F-010-B: restricted directory columns (no pay/tax/address) readable by any authenticated user.';
+
+-- 3. profiles: select limited to own row or managers; drop the duplicate policy.
+alter table public.profiles enable row level security;
+
+drop policy if exists "Anyone can view profiles" on public.profiles;
+drop policy if exists "Enable read access for all users" on public.profiles;
+drop policy if exists "profiles_select_manager_or_own" on public.profiles;
+create policy "profiles_select_manager_or_own"
+    on public.profiles
+    for select
+    to authenticated
+    using (
+        id = auth.uid()
+        or exists (select 1 from public.profiles p where p.id = auth.uid() and p.role = 'MANAGER')
+    );
+
+comment on policy "profiles_select_manager_or_own" on public.profiles is
+    'F-010-B: profile reads limited to managers and the profile''s own row.';
+
+-- 4. payroll_records: own-employee or manager (self-service paystubs + manager views).
+alter table public.payroll_records enable row level security;
+
+drop policy if exists "Enable read access for all users" on public.payroll_records;
+drop policy if exists "payroll_records_select_own_or_manager" on public.payroll_records;
+create policy "payroll_records_select_own_or_manager"
+    on public.payroll_records
+    for select
+    to authenticated
+    using (
+        employee_id in (select e.id from public.employees e where e.profile_id = auth.uid())
+        or exists (select 1 from public.profiles p where p.id = auth.uid() and p.role = 'MANAGER')
+    );
+
+comment on policy "payroll_records_select_own_or_manager" on public.payroll_records is
+    'F-010-B: payroll record reads limited to the owning employee or managers.';
+
+-- 5. Payroll runs, benefits, departments, time_entries: any authenticated read.
+alter table public.payroll_runs enable row level security;
+drop policy if exists "Anyone can view payroll runs" on public.payroll_runs;
+drop policy if exists "payroll_runs_select_authenticated" on public.payroll_runs;
+create policy "payroll_runs_select_authenticated"
+    on public.payroll_runs for select to authenticated using (true);
+
+alter table public.benefits enable row level security;
+drop policy if exists "Enable read access for all users" on public.benefits;
+drop policy if exists "benefits_select_authenticated" on public.benefits;
+create policy "benefits_select_authenticated"
+    on public.benefits for select to authenticated using (true);
+
+alter table public.departments enable row level security;
+drop policy if exists "Anyone can view departments" on public.departments;
+drop policy if exists "departments_select_authenticated" on public.departments;
+create policy "departments_select_authenticated"
+    on public.departments for select to authenticated using (true);
+
+alter table public.time_entries enable row level security;
+drop policy if exists "Everyone can view time_entries" on public.time_entries;
+drop policy if exists "time_entries_select_authenticated" on public.time_entries;
+create policy "time_entries_select_authenticated"
+    on public.time_entries for select to authenticated using (true);
+
+-- 6. employee_benefits: anonymous INSERT/UPDATE was a live hole. Writes are
+--    scoped to the acting employee's own enrollment row or managers; reads
+--    stay authenticated-only.
+alter table public.employee_benefits enable row level security;
+
+drop policy if exists "Allow all users to insert" on public.employee_benefits;
+drop policy if exists "Enable update access for all users" on public.employee_benefits;
+drop policy if exists "Enable read access for all users" on public.employee_benefits;
+drop policy if exists "employee_benefits_select_authenticated" on public.employee_benefits;
+drop policy if exists "employee_benefits_insert_own_or_manager" on public.employee_benefits;
+drop policy if exists "employee_benefits_update_own_or_manager" on public.employee_benefits;
+
+create policy "employee_benefits_select_authenticated"
+    on public.employee_benefits for select to authenticated using (true);
+
+create policy "employee_benefits_insert_own_or_manager"
+    on public.employee_benefits
+    for insert
+    to authenticated
+    with check (
+        employee_id in (select e.id from public.employees e where e.profile_id = auth.uid())
+        or exists (select 1 from public.profiles p where p.id = auth.uid() and p.role = 'MANAGER')
+    );
+
+create policy "employee_benefits_update_own_or_manager"
+    on public.employee_benefits
+    for update
+    to authenticated
+    using (
+        employee_id in (select e.id from public.employees e where e.profile_id = auth.uid())
+        or exists (select 1 from public.profiles p where p.id = auth.uid() and p.role = 'MANAGER')
+    )
+    with check (
+        employee_id in (select e.id from public.employees e where e.profile_id = auth.uid())
+        or exists (select 1 from public.profiles p where p.id = auth.uid() and p.role = 'MANAGER')
+    );
+
+commit;


### PR DESCRIPTION
## Summary
Ends anonymous read/write access on the data tables and adds a restricted-column directory view, based on the live policy audit of 2026-08-14 that showed public/qual=true SELECT on every data table and public INSERT/UPDATE on employee_benefits.

## Changes
- **F-010 (base, already merged?):** parameterize the Supabase client. *See note below.*
- **F-010-B:** RLS lockdown migration
  - `employees` / `profiles`: full reads only for managers or the row owner
  - `payroll_records`: own-employee or manager (self-service paystubs still work)
  - `payroll_runs`, `benefits`, `departments`, `time_entries`: authenticated-only reads
  - `employee_benefits`: writes scoped to own enrollment or managers (was anon-insertable/updatable)
  - New `employee_directory` view exposes only directory columns (id, name, position, phone, email) — no pay/tax/address. Internal-search reads it for non-managers; `database.types.ts` regenerated to match.
  - Strips the now-redundant `getColumnsForRole` app-layer masking.

## Applied & verified on the hosted project
- `supabase db push` applied; anonymous access is blocked live (anon → `[]` / 401; service_role → full).
- Note: the hosted `schema_migrations` was empty; the `tax_rate_history` step was dropped because that table only exists via the separate unmerged F-003-B branch.

## Testing
- `vitest` roles + employee suites pass (21 tests)
- tsc/lint/money-test failures are pre-existing on `main` (byte-identical failure set)
- Live PostgREST verification: anon can't read tables or view; service_role can.

## Note on F-010
This branch builds directly on `2e42ea7` (F-010 client parameterization). If F-010 is already merged, this PR is cleanly F-010-B; if not, both land together here.