### PR TITLE
test: fix 11 pre-existing type errors in test fixtures

### DIFF
--- a/app/employee/paystubs/__tests__/PayStubs.test.tsx
+++ b/app/employee/paystubs/__tests__/PayStubs.test.tsx
@@ -337,7 +337,6 @@ describe('PayStubsPage', () => {
         it('displays payment details section', async () => {
             const paystubs = [makeRawPaystubRow({
                 id: 'payroll-1',
-                pay_frequency: 'HOURLY',
             })];
             mockGetEmployeePaystubs.mockResolvedValue(paystubs);
 

--- a/app/employee/paystubs/__tests__/utils.test.ts
+++ b/app/employee/paystubs/__tests__/utils.test.ts
@@ -152,8 +152,6 @@ describe('processPaystubData', () => {
                 id: 'emp-1',
                 first_name: 'John',
                 last_name: 'Doe',
-                email: 'john@test.com',
-                hire_date: '2024-01-01',
                 pay_frequency: 'SALARY',
                 pay_rate: null,
                 address_line: null,

--- a/components/employee/optional-benefits-cards/__tests__/OptionalBenefitsCard.test.tsx
+++ b/components/employee/optional-benefits-cards/__tests__/OptionalBenefitsCard.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Vitest coverage for components/employee/optional-benefits-cards.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Tables } from '@/lib/interfaces/database.types';
 

--- a/lib/__tests__/supabase/benefits.test.ts
+++ b/lib/__tests__/supabase/benefits.test.ts
@@ -46,10 +46,10 @@ import type { Tables } from '@/lib/interfaces/database.types';
 
 const makeBenefit = (overrides: Partial<Tables<'benefits'>> = {}): Tables<'benefits'> => ({
     id: 'benefit-1',
-    name: 'Health Insurance',
+    benefit: 'Health Insurance',
     description: 'Company health coverage',
     type: 'COMPANY',
-    is_free: true,
+    tag: 'health',
     monthly_cost: null,
     provider: null,
     coverage: null,
@@ -66,10 +66,10 @@ describe('benefits data layer', () => {
         it('inserts new benefit successfully', async () => {
             mockAddBenefit.mockResolvedValue(undefined);
             const benefit: BenefitInsert = {
-                name: 'Dental',
+                benefit: 'Dental',
                 description: 'Dental coverage',
                 type: 'COMPANY',
-                is_free: true,
+                tag: 'dental',
             };
 
             await expect(addBenefit(benefit)).resolves.not.toThrow();
@@ -78,10 +78,10 @@ describe('benefits data layer', () => {
         it('throws error when insert fails', async () => {
             mockAddBenefit.mockRejectedValue(new Error('Insert failed'));
             const benefit: BenefitInsert = {
-                name: 'Dental',
+                benefit: 'Dental',
                 description: 'Dental coverage',
                 type: 'COMPANY',
-                is_free: true,
+                tag: 'dental',
             };
 
             await expect(addBenefit(benefit)).rejects.toThrow('Insert failed');
@@ -180,8 +180,8 @@ describe('benefits data layer', () => {
 
     describe('updateBenefit', () => {
         it('updates benefit successfully', async () => {
-            mockUpdateBenefit.mockResolvedValue({ id: 'benefit-1', name: 'Updated' });
-            const updates: BenefitUpdate = { name: 'Updated Health Insurance' };
+            mockUpdateBenefit.mockResolvedValue({ id: 'benefit-1', benefit: 'Updated' });
+            const updates: BenefitUpdate = { benefit: 'Updated Health Insurance' };
 
             const result = await updateBenefit('benefit-1', updates);
 
@@ -191,13 +191,13 @@ describe('benefits data layer', () => {
         it('throws error when update fails', async () => {
             mockUpdateBenefit.mockRejectedValue(new Error('Update failed'));
 
-            await expect(updateBenefit('benefit-1', { name: 'Updated' })).rejects.toThrow('Update failed');
+            await expect(updateBenefit('benefit-1', { benefit: 'Updated' })).rejects.toThrow('Update failed');
         });
     });
 
     describe('getActiveOptionalEmployeeBenefits', () => {
         it('returns active optional benefits for employee', async () => {
-            const employeeBenefits: Tables<'employee_benefits'>[] = [{ id: 'emp-benefit-1', employee_id: 'emp-1', benefit_id: 'benefit-1', status: 'ACTIVE', benefit: makeBenefit({ type: 'OPTIONAL' }) }];
+            const employeeBenefits = [{ id: 'emp-benefit-1', employee_id: 'emp-1', benefit_id: 'benefit-1', status: 'ACTIVE', benefit: makeBenefit({ type: 'OPTIONAL' }) } as Tables<'employee_benefits'> & { benefit: Tables<'benefits'> }];
             mockGetActiveOptionalEmployeeBenefits.mockResolvedValue(employeeBenefits);
 
             const result = await getActiveOptionalEmployeeBenefits('emp-1');

--- a/lib/__tests__/supabase/employee.test.ts
+++ b/lib/__tests__/supabase/employee.test.ts
@@ -67,6 +67,9 @@ describe('employee data layer', () => {
                 first_name: 'John',
                 last_name: 'Smith',
                 role: 'Engineer',
+                position: 'Engineer',
+                employee_number: 'E-1001',
+                hire_date: '2024-01-01',
                 pay_rate: 30,
                 pay_frequency: 'HOURLY',
                 federal_tax_rate: 0.22,
@@ -85,6 +88,9 @@ describe('employee data layer', () => {
                 first_name: 'John',
                 last_name: 'Smith',
                 role: 'Engineer',
+                position: 'Engineer',
+                employee_number: 'E-1001',
+                hire_date: '2024-01-01',
                 pay_rate: 30,
                 pay_frequency: 'HOURLY',
                 federal_tax_rate: 0.22,
@@ -153,12 +159,12 @@ describe('employee data layer', () => {
     describe('getCurrentEmployee', () => {
         it('returns current employee', async () => {
             const employee = makeEmployee();
-            mockGetCurrentEmployee.mockResolvedValue(employee);
+            mockGetCurrentEmployee.mockResolvedValue({ user: { id: 'user-1' }, profile: { id: 'user-1' }, employee });
 
             const result = await getCurrentEmployee();
 
             expect(result).toBeDefined();
-            expect(result.id).toBe('emp-1');
+            expect(result.employee.id).toBe('emp-1');
         });
 
         it('throws error when fetch fails', async () => {


### PR DESCRIPTION
## Summary
Fixes 11 pre-existing TypeScript type errors in test files to achieve clean tsc --noEmit.

## Changes
- Fix type mismatches in PayStubs.test.tsx, utils.test.ts, OptionalBenefitsCard.test.tsx
- Fix type issues in benefits.test.ts and employee.test.ts
- Add missing imports and type assertions

## Verification
- tsc --noEmit: 0 errors in source files
- npm run test:run passes